### PR TITLE
show correct info text if no filtered entries were found

### DIFF
--- a/src/components/FilteredList.js
+++ b/src/components/FilteredList.js
@@ -62,7 +62,7 @@ export default function FilteredList() {
   };
 
   const NoHelpNeeded = (props) => {
-    return <div className="w-full text-center my-10">In {location} wird gerade aktuell keine Hilfe gebraucht!</div>
+    return <div className="w-full text-center my-10">In {location} wird gerade keine Hilfe gebraucht!</div>
   };
 
   return (<div>
@@ -74,11 +74,10 @@ export default function FilteredList() {
           <Link to='/notify-me' className="btn-green-secondary my-3 mb-6 w-full block" onClick={() => fb.analytics.logEvent('button_subscribe_region')}>
             Benachrichtige mich wenn jemand in {location && location !== '' ? `der Nähe von ${location}` : 'meiner Nähe'} Hilfe braucht!</Link>
         </div>
-        {entries.length === 0 ? <NoHelpNeeded /> : filteredEntries.map(
+        {filteredEntries.length === 0 ? <NoHelpNeeded /> : filteredEntries.map(
           entry => (
             <Entry key={entry.id} {...entry}/>))}
       </div>
     </div>
   );
 }
-


### PR DESCRIPTION
* fixes #16 --> currently, the info text is not shown if the search returned no results
* updated info text (removed redundant word)

![Screenshot 2020-03-18 at 21 37 16](https://user-images.githubusercontent.com/20641332/77008976-6e390500-6967-11ea-9b6d-1b268a84d0b2.png)

@florianschmidt1994 