### PR TITLE
Fix React warning on dashboard page

### DIFF
--- a/src/views/Dashboard.jsx
+++ b/src/views/Dashboard.jsx
@@ -78,7 +78,7 @@ export default function Dashboard() {
           <div className="font-open-sans">
             Du hast noch keine Hilfegesuche eingestellt. Du kannst ein neues Gesuch
             {' '}
-            <Link class="text-secondary hover:underline" to="/ask-for-help" onClick={() => fb.analytics.logEvent('button_want_to_help')}>hier</Link>
+            <Link className="text-secondary hover:underline" to="/ask-for-help" onClick={() => fb.analytics.logEvent('button_want_to_help')}>hier</Link>
             {' '}
             erstellen.
           </div>
@@ -92,7 +92,7 @@ export default function Dashboard() {
           <div className="font-open-sans">
             Du hast noch keine Benachrichtigungen aktiviert. Du kannst neue Benachrichtigungen
             {' '}
-            <Link class="text-secondary hover:underline" to="/notify-me" onClick={() => fb.analytics.logEvent('button_want_to_help')}>hier</Link>
+            <Link className="text-secondary hover:underline" to="/notify-me" onClick={() => fb.analytics.logEvent('button_want_to_help')}>hier</Link>
             {' '}
             registrieren.
           </div>


### PR DESCRIPTION
The warning was:

> Warning: Invalid DOM property `class`. Did you mean `className`?