### PR TITLE
Fix usages of addEventListener in useEffect hook

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -30,6 +30,7 @@ import NotifyMe from './views/NotifyMe';
 import ScrollToTop from './components/ScrollToTop';
 import ShareButtons from './components/ShareButtons';
 import Presse from './views/Presse';
+import createEventListener from './util/createEventListener';
 
 function App(props) {
   const { t } = useTranslation();
@@ -48,11 +49,14 @@ function App(props) {
     };
     handleHashChange();
 
-    window.addEventListener('hashchange', handleHashChange);
+    return createEventListener(window, 'hashchange', handleHashChange);
   };
 
   useEffect(() => {
-    if (document.cookie.indexOf('cookieConsent') > -1) addListener();
+    if (document.cookie.indexOf('cookieConsent') > -1) {
+      return addListener();
+    }
+    return undefined;
   }, []);
 
   const [menuOpen, setMenuOpen] = useState(false);

--- a/src/components/ArrowDown.jsx
+++ b/src/components/ArrowDown.jsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import createEventListener from '../util/createEventListener';
 
 export default function ArrowDown(props) {
   const [visible, setVisible] = useState(false);
@@ -7,11 +8,11 @@ export default function ArrowDown(props) {
   const hideOffset = 100;
 
   useEffect(() => {
-    window.addEventListener('scroll', () => {
+    setVisible(window.pageYOffset < hideOffset);
+    return createEventListener(window, 'scroll', () => {
       setVisible(window.pageYOffset < hideOffset);
       setOpacity((hideOffset - window.pageYOffset) / hideOffset);
     });
-    setVisible(window.pageYOffset < hideOffset);
   }, []);
 
   if (visible) {

--- a/src/util/createEventListener.jsx
+++ b/src/util/createEventListener.jsx
@@ -1,0 +1,4 @@
+export default function createEventListener(obj, event, fn) {
+  obj.addEventListener(event, fn);
+  return () => obj.removeEventListener(event, fn);
+}


### PR DESCRIPTION
These hooks should return a function that removes the event listener.
Otherwise, there could be a reference to a component that has already
been removed, which causes an error to be logged in the console during
development.

**What changes does this PR introduce**

There should be no user-visible changes (except perhaps slightly better performance / lower memory usage).

**Checklist**
- [x] `yarn build` passes
- [x] `yarn lint` does not introduce any new errors (We know there are currently 12 errors and 9 warnings and working hard on removing them!)

**Others details**
- [ ] This PR introduces a new dependency.
  
If you have any questions be sure to let us know! For review ping anyone in this list:
 
 - @florianschmidt1994
 - @kenodressel
 - @Maurice22
 - @tgraupne
 