### PR TITLE
Disable remaining eslint warnings

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,7 +4,7 @@ _Briefly describe your changes here_
 
 **Checklist**
 - [ ] `yarn build` passes
-- [ ] `yarn lint` does not introduce any new errors (We know there are currently 12 errors and 9 warnings and working hard on removing them!)
+- [ ] `yarn lint` does not show any errors
 
 **Others details**
 - [ ] This PR introduces a new dependency. Reason: _Mention your reason for introducing this dependency here_

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -1,6 +1,12 @@
 import React, { Suspense } from 'react';
 import ReactDOM from 'react-dom';
+
+// At the time of linting style is not available yet.
+// in order to spare the CI the step of running yarn build
+// we ignore this check here.
+// eslint-disable-next-line import/no-unresolved
 import './styles/tailwind.css';
+
 import './styles/index.css';
 import './styles/App.css';
 import App from './App';

--- a/src/serviceWorker.jsx
+++ b/src/serviceWorker.jsx
@@ -1,3 +1,10 @@
+/* eslint-disable */
+// We don't use linting in this file because it was created by
+// create-react-app and we're not using this anyway. Should we
+// ever enable the service worker and modify the contents of this
+// file we should also enable linting again and fix the remaining
+// errors and warnings.
+
 // This optional code is used to register a service worker.
 // register() is not called by default.
 
@@ -36,7 +43,6 @@ export function register(config) {
 
       if (isLocalhost) {
         // This is running on localhost. Let's check if a service worker still exists or not.
-        // eslint-disable-next-line no-use-before-define
         checkValidServiceWorker(swUrl, config);
 
         // Add some additional logging to localhost, pointing developers to the
@@ -49,7 +55,6 @@ export function register(config) {
         });
       } else {
         // Is not localhost. Just register service worker
-        // eslint-disable-next-line no-use-before-define
         registerValidSW(swUrl, config);
       }
     });
@@ -60,7 +65,6 @@ function registerValidSW(swUrl, config) {
   navigator.serviceWorker
     .register(swUrl)
     .then((registration) => {
-      // eslint-disable-next-line no-param-reassign
       registration.onupdatefound = () => {
         const installingWorker = registration.installing;
         if (installingWorker == null) {

--- a/src/views/AskForHelp.jsx
+++ b/src/views/AskForHelp.jsx
@@ -51,6 +51,7 @@ export default function AskForHelp() {
     geocodeByAddress(address)
       .then((results) => getLatLng(results[0]))
       .then(setCoodinates)
+      // eslint-disable-next-line no-console
       .catch((error) => console.error('Error', error));
   };
 

--- a/src/views/CompleteOfferHelp.jsx
+++ b/src/views/CompleteOfferHelp.jsx
@@ -23,6 +23,7 @@ export default function CompleteOfferHelp() {
           // We only end up here if there is no email set in the localStorage of the users browser
           // this might happen e.g. if the user signs up on his desktop pc and clicks the confirmation
           // link in his mobile phones email client.
+          // eslint-disable-next-line no-alert
           email = window.prompt('Bitte geben sie die Email ein, mit der sie sich registriert haben');
         }
 


### PR DESCRIPTION
**What changes does this PR introduce**
This silences the remaining eslint errors. The primary motivation is to have a clean slate for future contributions and not always spam all pull requests with the eslint output of preexisting errors.

Closes #115

**Checklist**
- [x] `yarn build` passes
- [x] `yarn lint` does not introduce any new errors (We know there are currently 12 errors and 9 warnings and working hard on removing them!)

**Others details**
- [ ] This PR introduces a new dependency. Reason: _Mention your reason for introducing this dependency here_