### PR TITLE
Fix README codeblock

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ firebase init
 
 firebase deploy
 ...
-`
+```
 
 and follow the instructions.
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ You need the following libraries to get started: `node`, `yarn`, `firebase cli`.
 
 Once you've installed those dependencies, run the following inside the project folder
 
-```yarn install```
+`yarn install`
 
 This will install all JavaScript dependencies.
 
@@ -105,7 +105,7 @@ Or even better, replace all email-related source code with proper logging.
 
 After those changes, you should be able to initialize and deploy your own Firebase function to your specific backend. Within the project folder, run:
 
-```
+```console
 firebase init
 ...
 

--- a/src/components/Entry.jsx
+++ b/src/components/Entry.jsx
@@ -22,7 +22,7 @@ export default function Entry(props) {
 
   const { t } = useTranslation();
   const [user] = useAuthState(fb.auth);
-  
+
   const date = formatDistance(new Date(timestamp), Date.now(), { locale: de }); // @TODO get locale from i18n.language or use i18n for formatting
 
   let textToDisplay;
@@ -77,7 +77,8 @@ export default function Entry(props) {
           {location}
         </span>
         {' '}
-        {t('components.entry.needsHelp')}!
+        {t('components.entry.needsHelp')}
+        !
       </span>
       <p className="mt-2 mb-2 font-open-sans text-gray-800">{textToDisplay}</p>
       <div className="flex flex-row justify-between items-center mt-4 mb-2">

--- a/src/components/Entry.jsx
+++ b/src/components/Entry.jsx
@@ -22,7 +22,7 @@ export default function Entry(props) {
 
   const { t } = useTranslation();
   const [user] = useAuthState(fb.auth);
-
+  
   const date = formatDistance(new Date(timestamp), Date.now(), { locale: de }); // @TODO get locale from i18n.language or use i18n for formatting
 
   let textToDisplay;
@@ -77,8 +77,7 @@ export default function Entry(props) {
           {location}
         </span>
         {' '}
-        {t('components.entry.needsHelp')}
-        !
+        {t('components.entry.needsHelp')}!
       </span>
       <p className="mt-2 mb-2 font-open-sans text-gray-800">{textToDisplay}</p>
       <div className="flex flex-row justify-between items-center mt-4 mb-2">


### PR DESCRIPTION
**What changes does this PR introduce**
Again just a small thing...
The last code block of the `README` wasn't closed correctly which led to wrong formatting.
Also added a language qualifier to the console snippet.

**Checklist**
- [x] `yarn build` passes
- [x] `yarn lint` does not show any errors **(had to make minor changes in `Entry.jsx` to get rid of lint errors)**

@florianschmidt1994
 