### PR TITLE
Fix language for Google Maps API calls to german

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -32,7 +32,7 @@
       manifest.json provides metadata used when your web app is installed on a
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
     -->
-    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyDFCKxZqlzYTZ2MDnDrKnfe00jU8vJd4Yg&libraries=places"></script>
+    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyDFCKxZqlzYTZ2MDnDrKnfe00jU8vJd4Yg&language=de&region=DE&libraries=places"></script>
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json"/>
     <!--
       Notice the use of %PUBLIC_URL% in the tags above.


### PR DESCRIPTION
**What changes does this PR introduce**

Setting the language for Gmaps API Calls to german to prevent locations being displayed in different languages in the entries.

Fixes #160 

**Checklist**
- [x] `yarn build` passes
- [x] `yarn lint` does not show any errors