### PR TITLE
Ignore cypress screenshots and videos in git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,8 @@ crashlytics-build.properties
 fabric.properties
 
 # End of https://www.gitignore.io/api/react,webstorm,visualstudiocode
+
+# Cypress
+cypress/videos/*
+cypress/screenshots/*
+


### PR DESCRIPTION
**What changes does this PR introduce**
It adds cypress video output `/cypress/video/*` and screenshots `/cypress/screenshots/*`
 to `.gitignore`. I believe we should not have those in version control and it follows common practice as described in https://docs.cypress.io/guides/core-concepts/writing-and-organizing-tests.html#Folder-Structure

**Checklist**
- [x] `yarn build` passes
- [x] `yarn lint` does not show any errors
