### PR TITLE
Use correct OnePagers component on overview

### DIFF
--- a/src/components/OnePagers.jsx
+++ b/src/components/OnePagers.jsx
@@ -162,7 +162,7 @@ export default function OnePagers() {
   const { t } = useTranslation();
   const [isOpen, setIsOpen] = useState(false);
   return (
-    <div className="mb-8 md:mb-16">
+    <>
       <div
         className="mt-4 md:ml-0 md:mr-0 mb-1 p-4 flex flex-row md:flex-row justify-start items-center bg-kaki"
       >
@@ -209,7 +209,7 @@ export default function OnePagers() {
             />
           ))
         ) : null}
-    </div>
+    </>
   );
 }
 

--- a/src/components/OnePagers.jsx
+++ b/src/components/OnePagers.jsx
@@ -164,7 +164,7 @@ export default function OnePagers() {
   return (
     <div className="mb-8 md:mb-16">
       <div
-        className="mt-4 md:ml-0 md:mr-0 mx-4 mb-1 p-4 flex flex-row md:flex-row justify-start items-center bg-kaki"
+        className="mt-4 md:ml-0 md:mr-0 mb-1 p-4 flex flex-row md:flex-row justify-start items-center bg-kaki"
       >
         <div>
           <img className="w-30 h-10 md:h-16 mr-4" src={require('../assets/aushang.svg')} alt="" />
@@ -214,7 +214,7 @@ export default function OnePagers() {
 }
 
 const OnePager = (props) => (
-  <div className="md:ml-0 md:mr-0 mx-4 p-4 mb-1 bg-gray-custom">
+  <div className="md:ml-0 md:mr-0 p-4 mb-1 bg-gray-custom">
     <span className="font-semibold">
       {props.original}
     </span>

--- a/src/views/Main.jsx
+++ b/src/views/Main.jsx
@@ -56,7 +56,9 @@ export default function Main() {
           <Rules />
         </div>
 
-        <OnePagers />
+        <div className="mx-4 md:mx-0">
+          <OnePagers />
+        </div>
 
         <ArrowDown onClick={scrollTo} />
 

--- a/src/views/Main.jsx
+++ b/src/views/Main.jsx
@@ -56,7 +56,7 @@ export default function Main() {
           <Rules />
         </div>
 
-        <div className="mx-4 md:mx-0">
+        <div className="mx-4 md:mx-0 mb-8 md:mb-16">
           <OnePagers />
         </div>
 

--- a/src/views/Overview.jsx
+++ b/src/views/Overview.jsx
@@ -4,8 +4,7 @@ import FilteredList from '../components/FilteredList';
 import Footer from '../components/Footer';
 import OnePagers from '../components/OnePagers';
 
-// @TODO Should not this be named "Overview" since AskForHelp is already name of an other view?
-export default function AskForHelp() {
+export default function Overview() {
   const { t } = useTranslation();
   return (
     <div className="p-4">

--- a/src/views/Overview.jsx
+++ b/src/views/Overview.jsx
@@ -13,6 +13,7 @@ export default function Overview() {
         {t('views.overview.enterYourPostalCode')}
       </div>
       <OnePagers />
+      <div className="h-3 w-full" />
       <div className="py-3">
         <FilteredList pageSize={20} />
       </div>

--- a/src/views/Overview.jsx
+++ b/src/views/Overview.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
-import { Trans, useTranslation } from 'react-i18next';
+import { useTranslation } from 'react-i18next';
 import FilteredList from '../components/FilteredList';
 import Footer from '../components/Footer';
+import OnePagers from '../components/OnePagers';
 
 // @TODO Should not this be named "Overview" since AskForHelp is already name of an other view?
 export default function AskForHelp() {
@@ -12,19 +13,7 @@ export default function AskForHelp() {
       <div className="font-open-sans">
         {t('views.overview.enterYourPostalCode')}
       </div>
-      <div className="my-4 p-4 flex flex-row justify-start items-center bg-kaki">
-        <img className="w-30 h-10 md:h-16 mr-4" src={require('../assets/aushang.svg')} alt="" />
-        <p>
-          {t('views.overview.noInternet.preBreak')}
-          {' '}
-          <br className="sm:hidden" />
-          <Trans i18nKey="views.overview.noInternet.postBreak">
-            text
-            <a href="/assets/aushang.pdf" className="text-secondary hover:underline" download="/assets/aushang.pdf">text</a>
-            text
-          </Trans>
-        </p>
-      </div>
+      <OnePagers />
       <div className="py-3">
         <FilteredList pageSize={20} />
       </div>


### PR DESCRIPTION
**What changes does this PR introduce**

- Use the OnePagers component on /#/overview
- Refactor OnePagers to not have a margin
- Use wrapper div in Main.jsx for adding margin

Close #169

**Checklist**
- [x] `yarn build` passes
- [x] `yarn lint` does not show any errors
