### PR TITLE
Disable i18next debug logging

### DIFF
--- a/src/i18n.js
+++ b/src/i18n.js
@@ -17,7 +17,7 @@ i18n
   .init({
     fallbackLng: 'de', // @TODO Change to English as soon as we have English translations.
     lng: 'de',
-    debug: true,
+    debug: false,
 
     interpolation: {
       escapeValue: false, // not needed for react as it escapes by default


### PR DESCRIPTION
**What changes does this PR introduce**
The motivation for this change is that we do
not need the debug output logging from i18next
and it clutters the console

Close #176

**Checklist**
- [x] `yarn build` passes
- [x] `yarn lint` does not show any errors

**Others details**
- [ ] This PR introduces a new dependency. Reason: _Mention your reason for introducing this dependency here_
