### PR TITLE
Scroll to the right position when menu bar visible

### DIFF
--- a/src/views/Main.jsx
+++ b/src/views/Main.jsx
@@ -12,7 +12,7 @@ export default function Main() {
   const { t } = useTranslation();
 
   function scrollTo() {
-    const yOffset = -30;
+    const yOffset = window.matchMedia('(min-width: 835px)').matches ? -30 : -80;
     const el = document.getElementById('hilfe-buttons');
     if (el) {
       const y = el.getBoundingClientRect().top + window.pageYOffset + yOffset;

--- a/src/views/Main.jsx
+++ b/src/views/Main.jsx
@@ -12,7 +12,7 @@ export default function Main() {
   const { t } = useTranslation();
 
   function scrollTo() {
-    const yOffset = window.matchMedia('(min-width: 835px)').matches ? -30 : -80;
+    const yOffset = window.innerWidth >= 835 ? -30 : -80;
     const el = document.getElementById('hilfe-buttons');
     if (el) {
       const y = el.getBoundingClientRect().top + window.pageYOffset + yOffset;


### PR DESCRIPTION
**What changes does this PR introduce**

Scrolling down to thee right position on small screens now by adding a conditional offset based on the media query. The underlying issue is that we show the menu bar on mobile but not on desktop, so on mobile it overlaps the buttons.

**Checklist**
- [ ] `yarn build` passes
- [ ] `yarn lint` does not show any errors