### PR TITLE
Fix zero geocoding results to resolve to empty array

### DIFF
--- a/src/services/GeoService.js
+++ b/src/services/GeoService.js
@@ -8,14 +8,16 @@ export async function getSuggestions(searchString, searchOptions) {
     ...searchOptions,
     input: searchString,
   };
-  return new Promise((resolve, reject) => {
-    autocomplete.getPlacePredictions(request, (result, status) => {
-      if (status === 'OK') {
+  return new Promise((resolve, reject) => autocomplete.getPlacePredictions(request, (result, status) => {
+    switch (status) {
+      case 'OK':
         return resolve(result);
-      }
-      return reject(status);
-    });
-  });
+      case 'ZERO_RESULTS':
+        return resolve([]);
+      default:
+        return reject(status);
+    }
+  }));
 }
 
 export async function getGeodataForString(searchString, searchOptions) {


### PR DESCRIPTION
**What changes does this PR introduce**
Before applying this fix, the status 'ZERO_RESULTS' would mean
that we return a rejected Promise, which will be caught in LocationInput
and reported as an error to Sentry.

With this fix we resolve the Promise with an empty array and default to
rejecting the Promise for all other statuses.

I've tested that the input still works as expected manually

Close #189

**Checklist**
- [x] `yarn build` passes
- [x] `yarn lint` does not show any errors