### PR TITLE
fix delete for ask-for-help documents with updated firebase functions

### DIFF
--- a/src/components/Entry.jsx
+++ b/src/components/Entry.jsx
@@ -50,11 +50,11 @@ export default function Entry(props) {
 
   const handleDelete = async (e) => {
     e.preventDefault();
-    const doc = await fb.store.collection('/ask-for-help').doc(props.id).get();
-    await fb.store.collection('/deleted').add({
-      askForHelpId: doc.id, ...doc.data(),
+    const collectionName = 'ask-for-help';
+    const doc = await fb.store.collection(collectionName).doc(props.id).get();
+    await fb.store.collection('/deleted').doc(props.id).set({
+      collectionName, ...doc.data(),
     });
-    fb.store.collection('/ask-for-help').doc(props.id).delete();
     setDeleted(true);
   };
 


### PR DESCRIPTION
**What changes does this PR introduce**

* the updated firebase function for `/delete` requires the `collectionName` parameter, to know from which collection the responses subcollection should be migrated from
* [corresponding code in firebase functions](https://github.com/florianschmidt1994/quarantaenehelden-firebase-functions/blob/master/functions/index.js#L305)
* Currently, the  `collectionName`  is not set on delete, resulting in an error when trying to migrate the responses to the `deleted` collection

**Checklist**
- [ ] `yarn build` passes
- [ ] `yarn lint` does not show any errors

**Others details**
- [ ] This PR introduces a new dependency. Reason: _Mention your reason for introducing this dependency here_
 