### PR TITLE
add redirect to verify-email if email is not verified

### DIFF
--- a/src/views/AskForHelp.jsx
+++ b/src/views/AskForHelp.jsx
@@ -69,11 +69,11 @@ export default function AskForHelp() {
     setPlaceId(pId);
   };
 
-  if (!isAuthLoading && (!user || !user.email)) {
+  if (!user || (!isAuthLoading && (!user || !user.email))) {
     return <Redirect to="/signin/ask-for-help" />;
   }
 
-  if (!user || !user.emailVerified) {
+  if (!user.emailVerified) {
     return <Redirect to="/verify-email" />;
   }
 

--- a/src/views/AskForHelp.jsx
+++ b/src/views/AskForHelp.jsx
@@ -73,6 +73,10 @@ export default function AskForHelp() {
     return <Redirect to="/signin/ask-for-help" />;
   }
 
+  if (!user || !user.emailVerified) {
+    return <Redirect to="/verify-email" />;
+  }
+
   return (
     <form onSubmit={handleSubmit} className="p-4">
       <h1 className="font-teaser py-4 pt-10">{t('views.askForHelp.createRequest')}</h1>

--- a/src/views/VerifyEmail.jsx
+++ b/src/views/VerifyEmail.jsx
@@ -21,8 +21,15 @@ const VerifyEmail = (props) => {
     setSendVerificationSuccess(true);
   };
 
-  const recheckEmail = (e) => {
+  const recheckEmail = async (e) => {
     e.preventDefault();
+    // https://github.com/firebase/firebase-js-sdk/issues/2529
+    // https://stackoverflow.com/questions/47243702/firebase-token-email-verified-going-weird
+    // after an immediate sign up and email verification, "firebase.auth().currentUser.emailVerified" is set correctly
+    // however, "auth.token.email_verified" in the firebase backend gets ist value from the ID token which will not get updated until it expires or it is force refreshed
+    // therefore, we need to force refresh the ID token, to make the backend aware that the user is indeed verified, and passes the security rules
+    // by design, if the user would log out and log in again, the token would be refreshed as well
+    await firebaseAppAuth.currentUser.getIdToken(true);
     window.location.reload();
   };
 


### PR DESCRIPTION
**What changes does this PR introduce**

* fixes #197 (this is currently only happening on staging, since the firebase functions on prod have been updated yet)
* currently, a user with an unverified email can attempt to create a new listing, even though he should verify his email first
* the listing creation itself fails due to the security rules, which is fine
* additionally, the listing creation fails in the first session for a user even though if the user is verified
* the reason for this is the fact that the firebase backend is not aware yet that the user email is verified, for this we need to force refresh the ID token https://stackoverflow.com/questions/47243702/firebase-token-email-verified-going-weird

_Briefly describe your changes here_
* adds a redirect on the `ask-for-help` view to the `verify-email` view, if the user has not verified their email yet
* force refreshes the auth ID token on email verification

