### PR TITLE
fixes frontend deploy script

### DIFF
--- a/.github/workflows/deploy-frontend.sh
+++ b/.github/workflows/deploy-frontend.sh
@@ -24,6 +24,6 @@ git config user.email "github-actions-bot@users.noreply.github.com" && \
 git remote add origin "${REPO}" && \
 git checkout -b gh-pages && \
 git add * && \
-git commit -m "quarantaenehelden ${GIT_REV} deployment to gh-pages" && \
+git commit --allow-empty -m "quarantaenehelden ${GIT_REV} deployment to gh-pages" && \
 git fetch && git rebase -s recursive -Xtheirs origin/gh-pages && \
 git push origin gh-pages


### PR DESCRIPTION
**What changes does this PR introduce**

It now allows "empty" commits to gh-pages. This should remove the CI error when the deployed code is not updated. Is a fix to #194 