### PR TITLE
Fix/173 remove errors in auth dependencies

### DIFF
--- a/cypress/integration/landingpage.spec.js
+++ b/cypress/integration/landingpage.spec.js
@@ -27,13 +27,7 @@ context('Landing Page', () => {
     beforeEach(() => {
       cy.visit('localhost:3000');
 
-      // TODO: This yells ANTI-PATTERN. We should find a way to fix this
-      cy.wait(2000);
-      cy.get('body').then(($body) => {
-        if ($body.find('[data-cy=btn-sign-out]').length > 0) {
-          cy.get('[data-cy=btn-sign-out]').click();
-        }
-      });
+      indexedDB.deleteDatabase('firebaseLocalStorageDb');
 
       cy.visit('localhost:3000/#/signin');
       cy.get('form input[type="email"]').type('florian.schmidt.1994@icloud.com{enter}');

--- a/cypress/integration/landingpage.spec.js
+++ b/cypress/integration/landingpage.spec.js
@@ -2,6 +2,7 @@ context('Landing Page', () => {
 
   describe('User is not logged in', () => {
     beforeEach(() => {
+      indexedDB.deleteDatabase('firebaseLocalStorageDb');
       cy.visit('localhost:3000');
     });
 
@@ -57,6 +58,20 @@ context('Landing Page', () => {
     it('clicking on an entry should redirect to offer help', () => {
       cy.get('.entry').first().click();
       cy.hash().should('contain', '#/offer-help/');
+    });
+
+    it('clicking on "Meine Übersicht" should redirect to dashboard', () => {
+      cy.get('[data-cy=nav-my-overview]').click();
+      cy.hash().should('equal', '#/dashboard');
+    });
+
+    it('clicking on "Logout" should log out the user', () => {
+      cy.server();
+      cy.route('POST', 'https://www.googleapis.com/**').as('signOutUser');
+
+      cy.get('[data-cy=btn-sign-out]').click();
+      cy.get('[data-cy=btn-sign-out]').should('not.exist');
+      cy.get('[data-cy=nav-my-overview]').should('not.exist');
     });
   });
 });

--- a/cypress/integration/verifyEmail.spec.js
+++ b/cypress/integration/verifyEmail.spec.js
@@ -1,0 +1,43 @@
+context('Verify Email Page', () => {
+
+  describe('User is not logged in', () => {
+    beforeEach(() => {
+      indexedDB.deleteDatabase('firebaseLocalStorageDb');
+      cy.visit('localhost:3000/#/verify-email');
+    });
+
+    it('visiting the page should redirect to sign up', () => {
+      cy.hash().should('equal', '#/signup');
+    });
+  });
+
+  describe('User is logged in and his email address has not been verified', () => {
+
+    beforeEach(() => {
+      indexedDB.deleteDatabase('firebaseLocalStorageDb');
+      cy.visit('localhost:3000/#/signin');
+      cy.get('form input[type="email"]').type('not.verified@example.com{enter}');
+      cy.get('form input[type="password"]').type('test1234{enter}');
+    });
+
+    it('visiting the page should not redirect him', () => {
+      cy.visit('localhost:3000/#/verify-email');
+      cy.hash().should('equal', '#/verify-email');
+    });
+  });
+
+  describe('User is logged in and his email address has been verified', () => {
+
+    beforeEach(() => {
+      indexedDB.deleteDatabase('firebaseLocalStorageDb');
+      cy.visit('localhost:3000/#/signin');
+      cy.get('form input[type="email"]').type('verified@example.com{enter}');
+      cy.get('form input[type="password"]').type('test1234{enter}');
+    });
+
+    it('visiting the page should redirect to ask-for-help', () => {
+      cy.visit('localhost:3000/#/verify-email');
+      cy.hash().should('equal', '#/ask-for-help');
+    });
+  });
+});

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "react-scroll-up-button": "^1.6.4",
     "react-share": "^4.1.0",
     "react-slider": "^1.0.3",
-    "react-with-firebase-auth": "^1.3.0",
     "tailwindcss": "^1.2.0"
   },
   "scripts": {

--- a/public/locales/de/translation.json
+++ b/public/locales/de/translation.json
@@ -186,6 +186,7 @@
       "toHome": "ZUR STARTSEITE"
     },
     "signIn": {
+      "unknownError": "Unerwarteter Fehler beim Anmelden. Bitte versuche es erneut",
       "noUser": "Es existiert kein Nutzer mit dieser Email. Bitte registriere dich zuerst.",
       "wrongUserOrPw": "Falsche Email Adresse oder falsches Passwort angegeben.",
       "enterEmailForReset": "Bitte fülle das E-Mail Feld aus, um dein Passwort zurück zu setzen.",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -223,4 +223,3 @@ export default function App() {
     </div>
   );
 }
-

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -39,7 +39,6 @@ import createEventListener from './util/createEventListener';
 import Security from './views/Security';
 
 function TopNavigation({ isAuthLoading, user, signOut }) {
-
   const { t } = useTranslation();
 
   // if the user is not logged in or authentication is loading

--- a/src/views/Signin.jsx
+++ b/src/views/Signin.jsx
@@ -22,7 +22,7 @@ export default () => {
   const [passwordResetSuccess, setPasswordResetSuccess] = React.useState(false);
   const location = useLocation();
   const { t } = useTranslation();
-  const [user, isAuthLoading] = useAuthState(firebase.auth());
+  const [user] = useAuthState(firebase.auth());
   const signInWithEmailAndPassword = (mail, pw) => firebase.auth().signInWithEmailAndPassword(mail, pw);
 
   const { returnUrl } = useParams();

--- a/src/views/Signin.jsx
+++ b/src/views/Signin.jsx
@@ -44,7 +44,7 @@ export default function Signin() {
       const signInResult = await signInWithEmailAndPassword(email, password);
 
       if (!signInResult.user) {
-        setError('Unexpected error during sign in. Please try again!');
+        setError(t('views.signIn.unknownError'));
         Sentry.captureException(new Error('signInWithEmailAndPassword returned a result where the user property is null'));
         return;
       }

--- a/src/views/Signin.jsx
+++ b/src/views/Signin.jsx
@@ -16,7 +16,7 @@ import fb from '../firebase';
 
 import { baseUrl } from '../appConfig';
 
-export default () => {
+export default function Signin() {
   const [email, setEmail] = React.useState('');
   const [password, setPassword] = React.useState('');
   const [error, setError] = React.useState('');
@@ -138,4 +138,4 @@ export default () => {
       <Footer />
     </div>
   );
-};
+}

--- a/src/views/Signin.jsx
+++ b/src/views/Signin.jsx
@@ -1,6 +1,4 @@
 import React from 'react';
-import withFirebaseAuth from 'react-with-firebase-auth';
-import * as firebaseApp from 'firebase/app';
 import { useTranslation } from 'react-i18next';
 import 'firebase/auth';
 import {
@@ -9,25 +7,24 @@ import {
   useParams,
   useLocation,
 } from 'react-router-dom';
+import * as firebase from 'firebase/app';
+import { useAuthState } from 'react-firebase-hooks/auth';
 import Footer from '../components/Footer';
 import MailInput from '../components/MailInput';
 import fb from '../firebase';
+
 import { baseUrl } from '../appConfig';
 
-const firebaseAppAuth = firebaseApp.auth();
-
-const Signin = (props) => {
+export default () => {
   const [email, setEmail] = React.useState('');
   const [password, setPassword] = React.useState('');
   const [error, setError] = React.useState('');
   const [passwordResetSuccess, setPasswordResetSuccess] = React.useState(false);
   const location = useLocation();
   const { t } = useTranslation();
+  const [user, isAuthLoading] = useAuthState(firebase.auth());
+  const signInWithEmailAndPassword = (mail, pw) => firebase.auth().signInWithEmailAndPassword(mail, pw);
 
-  const {
-    user,
-    signInWithEmailAndPassword,
-  } = props;
   const { returnUrl } = useParams();
 
   if (user) {
@@ -42,18 +39,18 @@ const Signin = (props) => {
 
   const signIn = async (e) => {
     e.preventDefault();
-    const signInResult = await signInWithEmailAndPassword(email, password);
-    if (signInResult.code) {
-      switch (signInResult.code) {
+    try {
+      const signInResult = await signInWithEmailAndPassword(email, password);
+      if (!signInResult.user.emailVerified) await signInResult.user.sendEmailVerification();
+    } catch (err) {
+      switch (err.code) {
         case 'auth/user-not-found': setError(t('views.signIn.noUser')); break;
         case 'auth/wrong-password': setError(t('views.signIn.wrongUserOrPw')); break;
         case 'auth/invalid-email': setError(t('views.signIn.emailInvalid')); break;
         case 'auth/too-many-requests': setError(t('views.signIn.tooManyRequests')); break;
-        default: setError(signInResult.message);
+        default: setError(err.message);
       }
-      return;
     }
-    if (!signInResult.user.emailVerified) await signInResult.user.sendEmailVerification();
   };
 
   const sendPasswordResetMail = (e) => {
@@ -132,8 +129,3 @@ const Signin = (props) => {
     </div>
   );
 };
-
-export default withFirebaseAuth({
-  providers: [],
-  firebaseAppAuth,
-})(Signin);

--- a/src/views/VerifyEmail.jsx
+++ b/src/views/VerifyEmail.jsx
@@ -1,19 +1,22 @@
 import React from 'react';
 import { Redirect } from 'react-router-dom';
-import withFirebaseAuth from 'react-with-firebase-auth';
-import * as firebaseApp from 'firebase';
+import { useAuthState } from 'react-firebase-hooks/auth';
+import * as firebase from 'firebase/app';
+import 'firebase/auth';
 import Footer from '../components/Footer';
 
-const firebaseAppAuth = firebaseApp.auth();
 
-const VerifyEmail = (props) => {
+export default () => {
   const [sendVerificationSuccess, setSendVerificationSuccess] = React.useState(false);
+  const [user, isAuthLoading] = useAuthState(firebase.auth());
 
-  const {
-    user,
-  } = props;
+  if (!user && !isAuthLoading) {
+    return <Redirect to="/signup" />;
+  }
 
-  if (user && user.emailVerified) return <Redirect to="/ask-for-help" />;
+  if (user && user.emailVerified) {
+    return <Redirect to="/ask-for-help" />;
+  }
 
   const resendEmail = async (e) => {
     e.preventDefault();
@@ -29,7 +32,7 @@ const VerifyEmail = (props) => {
     // however, "auth.token.email_verified" in the firebase backend gets ist value from the ID token which will not get updated until it expires or it is force refreshed
     // therefore, we need to force refresh the ID token, to make the backend aware that the user is indeed verified, and passes the security rules
     // by design, if the user would log out and log in again, the token would be refreshed as well
-    await firebaseAppAuth.currentUser.getIdToken(true);
+    await user.getIdToken(true);
     window.location.reload();
   };
 
@@ -56,7 +59,3 @@ const VerifyEmail = (props) => {
   );
 };
 
-export default withFirebaseAuth({
-  providers: [],
-  firebaseAppAuth,
-})(VerifyEmail);

--- a/src/views/VerifyEmail.jsx
+++ b/src/views/VerifyEmail.jsx
@@ -58,4 +58,3 @@ export default () => {
     </div>
   );
 };
-

--- a/yarn.lock
+++ b/yarn.lock
@@ -1626,6 +1626,58 @@
   dependencies:
     any-observable "^0.3.0"
 
+"@sentry/browser@^5.15.4":
+  version "5.15.4"
+  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-5.15.4.tgz#5a7e7bad088556665ed8e69bceb0e18784e4f6c7"
+  integrity sha512-l/auT1HtZM3KxjCGQHYO/K51ygnlcuOrM+7Ga8gUUbU9ZXDYw6jRi0+Af9aqXKmdDw1naNxr7OCSy6NBrLWVZw==
+  dependencies:
+    "@sentry/core" "5.15.4"
+    "@sentry/types" "5.15.4"
+    "@sentry/utils" "5.15.4"
+    tslib "^1.9.3"
+
+"@sentry/core@5.15.4":
+  version "5.15.4"
+  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-5.15.4.tgz#08b617e093a636168be5aebad141d1f744217085"
+  integrity sha512-9KP4NM4SqfV5NixpvAymC7Nvp36Zj4dU2fowmxiq7OIbzTxGXDhwuN/t0Uh8xiqlkpkQqSECZ1OjSFXrBldetQ==
+  dependencies:
+    "@sentry/hub" "5.15.4"
+    "@sentry/minimal" "5.15.4"
+    "@sentry/types" "5.15.4"
+    "@sentry/utils" "5.15.4"
+    tslib "^1.9.3"
+
+"@sentry/hub@5.15.4":
+  version "5.15.4"
+  resolved "https://registry.yarnpkg.com/@sentry/hub/-/hub-5.15.4.tgz#cb64473725a60eec63b0be58ed1143eaaf894bee"
+  integrity sha512-1XJ1SVqadkbUT4zLS0TVIVl99si7oHizLmghR8LMFl5wOkGEgehHSoOydQkIAX2C7sJmaF5TZ47ORBHgkqclUg==
+  dependencies:
+    "@sentry/types" "5.15.4"
+    "@sentry/utils" "5.15.4"
+    tslib "^1.9.3"
+
+"@sentry/minimal@5.15.4":
+  version "5.15.4"
+  resolved "https://registry.yarnpkg.com/@sentry/minimal/-/minimal-5.15.4.tgz#113f01fefb86b7830994c3dfa7ad4889ba7b2003"
+  integrity sha512-GL4GZ3drS9ge+wmxkHBAMEwulaE7DMvAEfKQPDAjg2p3MfcCMhAYfuY4jJByAC9rg9OwBGGehz7UmhWMFjE0tw==
+  dependencies:
+    "@sentry/hub" "5.15.4"
+    "@sentry/types" "5.15.4"
+    tslib "^1.9.3"
+
+"@sentry/types@5.15.4":
+  version "5.15.4"
+  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-5.15.4.tgz#37f30e35b06e8e12ad1101f1beec3e9b88ca1aab"
+  integrity sha512-quPHPpeAuwID48HLPmqBiyXE3xEiZLZ5D3CEbU3c3YuvvAg8qmfOOTI6z4Z3Eedi7flvYpnx3n7N3dXIEz30Eg==
+
+"@sentry/utils@5.15.4":
+  version "5.15.4"
+  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-5.15.4.tgz#02865ab3c9b745656cea0ab183767ec26c96f6e6"
+  integrity sha512-lO8SLBjrUDGADl0LOkd55R5oL510d/1SaI08/IBHZCxCUwI4TiYo5EPECq8mrj3XGfgCyq9osw33bymRlIDuSQ==
+  dependencies:
+    "@sentry/types" "5.15.4"
+    tslib "^1.9.3"
+
 "@sheerun/mutationobserver-shim@^0.3.2":
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/@sheerun/mutationobserver-shim/-/mutationobserver-shim-0.3.3.tgz#5405ee8e444ed212db44e79351f0c70a582aae25"
@@ -10506,11 +10558,6 @@ react-transition-group@^4.3.0:
     loose-envify "^1.4.0"
     prop-types "^15.6.2"
 
-react-with-firebase-auth@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/react-with-firebase-auth/-/react-with-firebase-auth-1.3.0.tgz#585acbc742ab100e8cfa60dcb486fa55161e7e68"
-  integrity sha512-RBiiFy8543qarmBCVBgSARYZ0fwtI73KLa2o05wHJgEnPcFNzAQd7SFUczWnvAJdBr8AiqywvrTp8e+kE5br3g==
-
 react@^16.13.0:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react/-/react-16.13.1.tgz#2e818822f1a9743122c063d6410d85c1e3afe48e"
@@ -10794,7 +10841,7 @@ request@^2.87.0, request@^2.88.0:
     tunnel-agent "^0.6.0"
     uuid "^3.3.2"
 
-"request@github:cypress-io/request#b5af0d1fa47eec97ba980cde90a13e69a2afcd16":
+request@cypress-io/request#b5af0d1fa47eec97ba980cde90a13e69a2afcd16:
   version "2.88.1"
   resolved "https://codeload.github.com/cypress-io/request/tar.gz/b5af0d1fa47eec97ba980cde90a13e69a2afcd16"
   dependencies:
@@ -12077,7 +12124,7 @@ ts-pnp@^1.1.2:
   resolved "https://registry.yarnpkg.com/ts-pnp/-/ts-pnp-1.1.6.tgz#389a24396d425a0d3162e96d2b4638900fdc289a"
   integrity sha512-CrG5GqAAzMT7144Cl+UIFP7mz/iIhiy+xQ6GGcnjTezhALT02uPMRw7tgDSESgB5MsfKt55+GPWw4ir1kVtMIQ==
 
-tslib@1.11.1, tslib@^1.10.0, tslib@^1.8.1, tslib@^1.9.0:
+tslib@1.11.1, tslib@^1.10.0, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
   version "1.11.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.11.1.tgz#eb15d128827fbee2841549e171f45ed338ac7e35"
   integrity sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA==


### PR DESCRIPTION
**What changes does this PR introduce**
This change replaces the withFirebaseAuth higher order component with the `useAuthState()` hook that we use in most of the places anyway.

This PR includes
- Replacing HoC with hook in App
- Replacing HoC with hook in Signin
- Replacing HoC with hook in SignUp
- Replacing HoC with hook in VerifyEmail
- Adds test coverage for navigation in landingpage
- Adds test coverage for verifyEmail
- Changes behaviour in verifyEmail. Before: signed in and verified user would see the page. After: signed in and verified user will be redirected to /#/ask-for-help

I've originally approached these changes in order to remove the warning from #173, but I've figured once I'm at it I could even remove all the HoC occurrences as well.

**Others details**
- [x] This PR removes a dependency. Reason: react-with-firebase-auth is no longer needed  
