### PR TITLE
Enhancement/66 tighten eslint rules

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -35,7 +35,7 @@
         "object-curly-newline": [
             "error",
             {
-                "multiline": true
+                "consistent": true
             }
         ]
     }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -31,7 +31,6 @@
     "rules": {
         "max-len": "off",
         "react/prop-types": "off",
-        "react/destructuring-assignment": "off",
         "global-require": "off",
         "react/jsx-props-no-spreading": "off"
     }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -35,7 +35,7 @@
         "react/no-unescaped-entities": "off",
         "global-require": "off",
         "react/jsx-props-no-spreading": "off",
-        "jsx-a11y/label-has-associated-control": "off",
+        "jsx-a11y/label-has-associated-control": "error",
         "prefer-destructuring": "error",
         "jsx-a11y/click-events-have-key-events": "off",
         "jsx-a11y/no-static-element-interactions": "error"

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -34,10 +34,6 @@
         "react/destructuring-assignment": "off",
         "react/no-unescaped-entities": "off",
         "global-require": "off",
-        "react/jsx-props-no-spreading": "off",
-        "jsx-a11y/label-has-associated-control": "error",
-        "prefer-destructuring": "error",
-        "jsx-a11y/click-events-have-key-events": "off",
-        "jsx-a11y/no-static-element-interactions": "error"
+        "react/jsx-props-no-spreading": "off"
     }
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -31,6 +31,12 @@
     "rules": {
         "max-len": "off",
         "react/prop-types": "off",
-        "global-require": "off"
+        "global-require": "off",
+        "object-curly-newline": [
+            "error",
+            {
+                "multiline": true
+            }
+        ]
     }
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -38,6 +38,6 @@
         "jsx-a11y/label-has-associated-control": "off",
         "prefer-destructuring": "error",
         "jsx-a11y/click-events-have-key-events": "off",
-        "jsx-a11y/no-static-element-interactions": "off"
+        "jsx-a11y/no-static-element-interactions": "error"
     }
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -36,7 +36,7 @@
         "global-require": "off",
         "react/jsx-props-no-spreading": "off",
         "jsx-a11y/label-has-associated-control": "off",
-        "prefer-destructuring": "off",
+        "prefer-destructuring": "error",
         "jsx-a11y/click-events-have-key-events": "off",
         "jsx-a11y/no-static-element-interactions": "off"
     }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -31,7 +31,6 @@
     "rules": {
         "max-len": "off",
         "react/prop-types": "off",
-        "global-require": "off",
-        "react/jsx-props-no-spreading": "off"
+        "global-require": "off"
     }
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -32,7 +32,6 @@
         "max-len": "off",
         "react/prop-types": "off",
         "react/destructuring-assignment": "off",
-        "react/no-unescaped-entities": "off",
         "global-require": "off",
         "react/jsx-props-no-spreading": "off"
     }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -104,7 +104,7 @@ export default function App() {
     // Firebase analytics
     fb.analytics = fb.app.analytics();
     const handleHashChange = () => {
-      const hash = document.location.hash;
+      const { hash } = document.location;
       fb.analytics.logEvent('page_view', { page_path: hash.substring(1) });
     };
     handleHashChange();

--- a/src/components/ArrowDown.jsx
+++ b/src/components/ArrowDown.jsx
@@ -17,9 +17,9 @@ export default function ArrowDown(props) {
 
   if (visible) {
     return (
-      <div style={{ opacity }} className="arrow-more-content flex items-center justify-center w-full" onClick={() => props.onClick()}>
+      <button type="button" style={{ opacity }} className="arrow-more-content flex items-center justify-center w-full" onClick={() => props.onClick()}>
         <img alt="arrow-down" className="mt-1" src={require('../assets/arrow_down.svg')} />
-      </div>
+      </button>
     );
   }
   return null;

--- a/src/components/DesktopMenu.jsx
+++ b/src/components/DesktopMenu.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 import Box from '@material-ui/core/Box';
 import { useTranslation } from 'react-i18next';
 
-export default function DesktopMenu(props) {
+export default function DesktopMenu() {
   const { t } = useTranslation();
 
   const MenuItem = (menuItemProps) => (
@@ -29,7 +29,7 @@ export default function DesktopMenu(props) {
         <Link className="-ml-8 block -mt-12" to="/">
           <img alt="logo" src={require('../assets/logo.svg')} />
         </Link>
-        <Menu {...props} />
+        <Menu />
       </div>
     </>
   );

--- a/src/components/EntryList.jsx
+++ b/src/components/EntryList.jsx
@@ -207,7 +207,18 @@ export default function EntryList({ pageSize = 0 }) {
           })}
         </div>
       ) : (
-        entries.map((entry) => <Entry key={entry.id} {...entry} />)
+        entries.map((entry) => (
+          <Entry
+            key={entry.id}
+            location={entry.location}
+            id={entry.id}
+            request={entry.request}
+            timestamp={entry.timestamp}
+            responses={entry.responses}
+            reportedBy={entry.reportedBy}
+            uid={entry.uid}
+          />
+        ))
       )}
       {pageSize > 0 && !searching ? (
         <div className="flex justify-center pt-3">

--- a/src/components/EntryMap.jsx
+++ b/src/components/EntryMap.jsx
@@ -114,12 +114,12 @@ export default function EntryMap() {
                 >
                   <button
                     type="button"
-                    className={`cluster-marker ${
+                    className={`cluster-marker focus:outline-none ${
                       lastSelectedMarkerId === cluster.id ? 'cm-selected' : ''
                     }`}
                     style={{
-                      width: `${10 + (pointCount / entries.length) * 20}px`,
-                      height: `${10 + (pointCount / entries.length) * 20}px`,
+                      width: `${22 + (pointCount / entries.length) * 100}px`,
+                      height: `${22 + (pointCount / entries.length) * 100}px`,
                     }}
                     onClick={() => {
                       setLastSelectedMarkerId(cluster.id);
@@ -161,14 +161,14 @@ export default function EntryMap() {
               >
                 <button
                   type="button"
-                  className={`help-request-marker ${
+                  className={`help-request-marker focus:outline-none flex ${
                     lastSelectedMarkerId === cluster.properties.id
                       ? 'hrm-selected'
                       : ''
                   }`}
                   style={{
-                    width: `${10 + (pointCount / entries.length) * 20}px`,
-                    height: `${10 + (pointCount / entries.length) * 20}px`,
+                    width: `${22 + (pointCount / entries.length) * 100}px`,
+                    height: `${22 + (pointCount / entries.length) * 100}px`,
                   }}
                   onClick={() => {
                     setLastSelectedMarkerId(cluster.properties.id);

--- a/src/components/EntryMap.jsx
+++ b/src/components/EntryMap.jsx
@@ -112,7 +112,8 @@ export default function EntryMap() {
                   lat={latitude}
                   lng={longitude}
                 >
-                  <div
+                  <button
+                    type="button"
                     className={`cluster-marker ${
                       lastSelectedMarkerId === cluster.id ? 'cm-selected' : ''
                     }`}
@@ -147,7 +148,7 @@ export default function EntryMap() {
                     }}
                   >
                     <p className="font-open-sans">{pointCount}</p>
-                  </div>
+                  </button>
                 </Marker>
               );
             }
@@ -158,7 +159,8 @@ export default function EntryMap() {
                 lat={latitude}
                 lng={longitude}
               >
-                <div
+                <button
+                  type="button"
                   className={`help-request-marker ${
                     lastSelectedMarkerId === cluster.properties.id
                       ? 'hrm-selected'
@@ -179,7 +181,7 @@ export default function EntryMap() {
                     alt="help-marker"
                     src={require('../assets/need_help.png')}
                   />
-                </div>
+                </button>
               </Marker>
             );
           })}

--- a/src/components/EntryMap.jsx
+++ b/src/components/EntryMap.jsx
@@ -202,7 +202,18 @@ export default function EntryMap() {
           {t('components.map.selectALocationFirst')}
         </p>
       ) : (
-        selectedHelpRequests.map((entry) => <Entry key={entry.id} {...entry} />)
+        selectedHelpRequests.map((entry) => (
+          <Entry
+            key={entry.id}
+            location={entry.location}
+            id={entry.id}
+            request={entry.request}
+            timestamp={entry.timestamp}
+            responses={entry.responses}
+            reportedBy={entry.reportedBy}
+            uid={entry.uid}
+          />
+        ))
       )}
     </div>
   );

--- a/src/components/LocationInput.jsx
+++ b/src/components/LocationInput.jsx
@@ -1,14 +1,22 @@
-import React, { useRef, useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import * as Sentry from '@sentry/browser';
 import { isMapsApiEnabled } from '../featureFlags';
 import { getSuggestions } from '../services/GeoService';
 
 export default function LocationInput(props) {
+  const {
+    required,
+    value,
+    onChange,
+    onSelect,
+  } = props;
+
   if (isMapsApiEnabled) {
-    return <Autocomplete {...props} />;
+    return <Autocomplete required={required} value={value} onChange={onChange} onSelect={onSelect} />;
   }
-  return <ZipCodeInput {...props} />;
+
+  return <ZipCodeInput required={required} value={value} onChange={onChange} onSelect={onSelect} />;
 }
 
 function ZipCodeInput(props) {
@@ -216,7 +224,6 @@ function AutocompleteSuggestion(props) {
       type="button"
       className="px-3 py-2 hover:bg-gray-100 cursor-pointer"
       onClick={onClick}
-      {...props}
     >
       <span>{suggestion.description}</span>
     </button>

--- a/src/components/LocationInput.jsx
+++ b/src/components/LocationInput.jsx
@@ -6,6 +6,7 @@ import { getSuggestions } from '../services/GeoService';
 
 export default function LocationInput(props) {
   const {
+    fullText,
     required,
     value,
     onChange,
@@ -13,7 +14,7 @@ export default function LocationInput(props) {
   } = props;
 
   if (isMapsApiEnabled) {
-    return <Autocomplete required={required} value={value} onChange={onChange} onSelect={onSelect} />;
+    return <Autocomplete required={required} value={value} onChange={onChange} onSelect={onSelect} fullText={fullText} />;
   }
 
   return <ZipCodeInput required={required} value={value} onChange={onChange} onSelect={onSelect} />;

--- a/src/components/LocationInput.jsx
+++ b/src/components/LocationInput.jsx
@@ -29,7 +29,7 @@ function ZipCodeInput(props) {
       clearTimeout(scheduledChange);
     }
 
-    const value = e.target.value;
+    const { value } = e.target;
     if (value.length >= 4 && value.length <= 5) {
       e.target.setCustomValidity('');
     } else {
@@ -142,7 +142,7 @@ function Autocomplete(props) {
   };
 
   const validateKeypress = (event) => {
-    const key = event.key;
+    const { key } = event;
     const keyInvalid = !fullText && key.length === 1 && !(/\d/.test(key));
     if (keyInvalid) {
       event.preventDefault();

--- a/src/components/LocationInput.jsx
+++ b/src/components/LocationInput.jsx
@@ -212,12 +212,13 @@ function AutocompleteSuggestion(props) {
   } = props;
 
   return (
-    <div
+    <button
+      type="button"
       className="px-3 py-2 hover:bg-gray-100 cursor-pointer"
       onClick={onClick}
       {...props}
     >
       <span>{suggestion.description}</span>
-    </div>
+    </button>
   );
 }

--- a/src/components/LocationInput.jsx
+++ b/src/components/LocationInput.jsx
@@ -24,8 +24,8 @@ function ZipCodeInput(props) {
   const {
     required = true,
     defaultValue = '',
-    onChange = () => {},
-    onChangeDebounced = () => {},
+    onChange = () => { },
+    onChangeDebounced = () => { },
     debounce = 200,
   } = props;
 
@@ -73,7 +73,7 @@ function Autocomplete(props) {
   const {
     required = true,
     defaultValue = '',
-    onChange = () => {},
+    onChange = () => { },
     fullText = false,
     onChangeDebounced = () => { },
     debounce = 200,
@@ -87,6 +87,8 @@ function Autocomplete(props) {
   const [scheduledChange, setScheduledChange] = useState(undefined);
   const [suggestions, setSuggestions] = useState([]);
   const [waitingForResults, setWaitingForResults] = useState(false);
+
+  const [selectionIndex, setSelectionIndex] = useState(-1);
 
   const loadSuggestions = async (searchValue) => {
     if (searchValue && searchValue.length >= minSearchInput) {
@@ -158,18 +160,36 @@ function Autocomplete(props) {
     }
   };
 
+  const handleKeyDown = (event) => {
+    const { keyCode } = event;
+    if (keyCode === 38) {
+      setSelectionIndex((prevIdx) => {
+        if (prevIdx === 0 && inputRef.current) {
+          inputRef.current.focus();
+        }
+        return prevIdx > -1 ? prevIdx - 1 : -1;
+      });
+      event.preventDefault();
+    }
+    if (keyCode === 40) {
+      setSelectionIndex((prevIdx) => (prevIdx < suggestions.length - 1 ? prevIdx + 1 : suggestions.length - 1));
+      event.preventDefault();
+    }
+  };
+
   useEffect(setInvalidNoSelect, []);
 
   const loadingVisible = (inputRef.current && inputRef.current.value.length < minSearchInput) || waitingForResults;
 
   return (
-    <div className="relative">
+    <div role="combobox" aria-controls="suggestion-box" aria-expanded={suggestions.length > 0} className="relative" tabIndex="0" onKeyDown={handleKeyDown}>
       <input
         ref={inputRef}
         className="location-search-input appearance-none input-focus truncate"
         style={{ paddingRight: '45px' }}
         defaultValue={defaultValue}
         onChange={(e) => {
+          setSelectionIndex(-1);
           handleChange(e.target.value);
         }}
         onKeyDown={validateKeypress}
@@ -185,10 +205,12 @@ function Autocomplete(props) {
           fillLevel={inputRef.current && inputRef.current.value.length}
         />
       )}
-      <div className="absolute w-full bg-white shadow-xl z-10">
-        {suggestions.map((s) => (
+      <div id="suggestion-box" className="absolute w-full bg-white shadow-xl z-10">
+        {suggestions.map((s, i) => (
           <AutocompleteSuggestion
             key={s.description}
+            index={i}
+            selectionIndex={selectionIndex}
             suggestion={s}
             onClick={() => handleSelect(s)}
           />
@@ -217,13 +239,24 @@ function LoadingIndicator(props) {
 function AutocompleteSuggestion(props) {
   const {
     suggestion,
+    index,
+    selectionIndex,
     onClick,
   } = props;
 
+  const ref = useRef();
+
+  useEffect(() => {
+    if (selectionIndex === index && ref.current) {
+      ref.current.focus();
+    }
+  }, [index, selectionIndex]);
+
   return (
     <button
+      ref={ref}
       type="button"
-      className="px-3 py-2 hover:bg-gray-100 cursor-pointer"
+      className="px-3 py-2 hover:bg-gray-100 focus:bg-gray-100 cursor-pointer w-full text-left"
       onClick={onClick}
     >
       <span>{suggestion.description}</span>

--- a/src/components/OnePagers.jsx
+++ b/src/components/OnePagers.jsx
@@ -213,26 +213,36 @@ export default function OnePagers() {
   );
 }
 
-const OnePager = (props) => (
-  <div className="md:ml-0 md:mr-0 p-4 mb-1 bg-gray-custom">
-    <span className="font-semibold">
-      {props.original}
-    </span>
-    {' | '}
-    <a
-      className="text-secondary hover:underline"
-      href={`../assets/${props.signUpFileName}`}
-      download={`../assets/${props.signUpFileName}`}
-    >
-      {props.signUp}
-    </a>
-    {' | '}
-    <a
-      className="text-secondary hover:underline"
-      href={`../assets/${props.posterFileName}`}
-      download={`../assets/${props.posterFileName}`}
-    >
-      {props.poster}
-    </a>
-  </div>
-);
+const OnePager = (props) => {
+  const {
+    original,
+    signUp,
+    signUpFileName,
+    posterFileName,
+    poster,
+  } = props;
+
+  return (
+    <div className="md:ml-0 md:mr-0 p-4 mb-1 bg-gray-custom">
+      <span className="font-semibold">
+        {original}
+      </span>
+      {' | '}
+      <a
+        className="text-secondary hover:underline"
+        href={`../assets/${signUpFileName}`}
+        download={`../assets/${signUpFileName}`}
+      >
+        {signUp}
+      </a>
+      {' | '}
+      <a
+        className="text-secondary hover:underline"
+        href={`../assets/${posterFileName}`}
+        download={`../assets/${posterFileName}`}
+      >
+        {poster}
+      </a>
+    </div>
+  );
+};

--- a/src/components/Responses.jsx
+++ b/src/components/Responses.jsx
@@ -34,12 +34,12 @@ const Response = ({ response }) => {
   );
 };
 
-export default function Responses(props) {
+export default function Responses({ id }) {
   const [responses, setResponses] = useState(undefined);
 
   useEffect(() => {
-    loadResponses(props.id).then(setResponses);
-  }, [props.id]);
+    loadResponses(id).then(setResponses);
+  }, [id]);
 
   return (
     <div>

--- a/src/components/entry/Entry.jsx
+++ b/src/components/entry/Entry.jsx
@@ -116,11 +116,11 @@ export default function Entry(props) {
     }
 
     const commonButtonClasses = 'px-6 py-3 uppercase font-open-sans font-bold text-center';
-    const expandIconProps = {
-      className: 'ml-2',
-      style: {
-        fontSize: '32px', marginTop: '-4px', marginBottom: '-4px', verticalAlign: 'bottom',
-      },
+    const expandIconPropsStyle = {
+      fontSize: '32px',
+      marginTop: '-4px',
+      marginBottom: '-4px',
+      verticalAlign: 'bottom',
     };
 
     return (
@@ -136,12 +136,12 @@ export default function Entry(props) {
               {responsesVisible ? (
                 <>
                   {t('components.entry.hideResponses', { count: responses })}
-                  <ExpandLessIcon {...expandIconProps} />
+                  <ExpandLessIcon className="ml-2" style={expandIconPropsStyle} />
                 </>
               ) : (
                 <>
                   {t('components.entry.showResponses', { count: responses })}
-                  <ExpandMoreIcon {...expandIconProps} />
+                  <ExpandMoreIcon className="ml-2" style={expandIconPropsStyle} />
                 </>
               )}
             </button>

--- a/src/components/entry/Entry.jsx
+++ b/src/components/entry/Entry.jsx
@@ -52,8 +52,8 @@ export default function Entry(props) {
   const handleDelete = async (e) => {
     e.preventDefault();
     const collectionName = 'ask-for-help';
-    const doc = await fb.store.collection(collectionName).doc(props.id).get();
-    await fb.store.collection('/deleted').doc(props.id).set({
+    const doc = await fb.store.collection(collectionName).doc(id).get();
+    await fb.store.collection('/deleted').doc(id).set({
       collectionName, ...doc.data(),
     });
     setDeleted(true);
@@ -108,7 +108,7 @@ export default function Entry(props) {
     setResponsesVisible(!responsesVisible);
   };
 
-  const mayDeleteEntryAndSeeResponses = user && (user.uid === props.uid || user.uid === 'gwPMgUwQyNWMI8LpMBIaJcDvXPc2');
+  const mayDeleteEntryAndSeeResponses = user && (user.uid === uid || user.uid === 'gwPMgUwQyNWMI8LpMBIaJcDvXPc2');
 
   const buttonBar = (() => {
     if (!mayDeleteEntryAndSeeResponses) {
@@ -161,7 +161,7 @@ export default function Entry(props) {
 
   const requestCard = (
     <Link
-      to={entryBelongsToCurrentUser ? '/dashboard' : `/offer-help/${props.id}`}
+      to={entryBelongsToCurrentUser ? '/dashboard' : `/offer-help/${id}`}
       className={`entry bg-white px-4 py-2 rounded w-full my-3 text-xl block entry relative break-words ${highlightLeft && 'border-l-4 border-secondary'}`}
       key={id}
       ref={link}

--- a/src/components/entry/Entry.jsx
+++ b/src/components/entry/Entry.jsx
@@ -198,12 +198,18 @@ export default function Entry(props) {
         ) : null}
         {attemptingToReport
           ? (
-            <button
-              type="button"
+            <div
+              role="button"
+              tabIndex="0"
               className="absolute inset-0 bg-white-75"
               onClick={(e) => {
                 e.preventDefault();
                 setAttemptingToReport((curr) => !curr);
+              }}
+              onKeyDown={(e) => {
+                if (e.keyCode === 13) {
+                  setAttemptingToReport((curr) => !curr);
+                }
               }}
             >
               <button
@@ -214,7 +220,7 @@ export default function Entry(props) {
                 Post melden?
                 <img className="ml-2 inline-block" src={require('../../assets/flag_white.svg')} alt="" />
               </button>
-            </button>
+            </div>
           ) : null}
 
       </div>

--- a/src/components/entry/Entry.jsx
+++ b/src/components/entry/Entry.jsx
@@ -198,7 +198,8 @@ export default function Entry(props) {
         ) : null}
         {attemptingToReport
           ? (
-            <div
+            <button
+              type="button"
               className="absolute inset-0 bg-white-75"
               onClick={(e) => {
                 e.preventDefault();
@@ -213,7 +214,7 @@ export default function Entry(props) {
                 Post melden?
                 <img className="ml-2 inline-block" src={require('../../assets/flag_white.svg')} alt="" />
               </button>
-            </div>
+            </button>
           ) : null}
 
       </div>

--- a/src/styles/Map.css
+++ b/src/styles/Map.css
@@ -3,16 +3,19 @@
   background: #b6223e;
   box-shadow: 3px 3px 10px 0px rgba(0,0,0,0.75);
   border-radius: 50%;
-  padding: 15px;
   display: flex;
   justify-content: center;
   align-items: center;
+  position: absolute;
+  transform: translate(-50%, -50%);
 }
 
 .cm-selected {
   background-color: #dd4864;
   transform: scale(1.25);
   box-shadow: 3px 3px 10px 0px rgba(0,0,0);
+  position: absolute;
+  transform: translate(-50%, -50%);
 }
 
 .help-request-marker {

--- a/src/views/CompleteOfferHelp.jsx
+++ b/src/views/CompleteOfferHelp.jsx
@@ -19,6 +19,7 @@ export default function CompleteOfferHelp() {
         const emailRegex = window.location.href.match(/email=([^&]*)/);
         let email;
         if (emailRegex && emailRegex.length > 1 && emailRegex[1]) {
+          // eslint-disable-next-line prefer-destructuring
           email = emailRegex[1];
         } else {
           // TODO: Use nice input for this!

--- a/src/views/Dashboard.jsx
+++ b/src/views/Dashboard.jsx
@@ -24,9 +24,9 @@ function Notification(props) {
         {props.location}
         {' '}
         {t('views.dashboard.needsHelp')}
-        <div className="cursor-pointer font-bold" onClick={onDeleteClick}>
+        <button type="button" className="cursor-pointer font-bold" onClick={onDeleteClick}>
           &times;
-        </div>
+        </button>
       </div>
     </div>
   );

--- a/src/views/Dashboard.jsx
+++ b/src/views/Dashboard.jsx
@@ -11,7 +11,9 @@ const offerHelpCollection = fb.store.collection('offer-help');
 
 function Notification(props) {
   const { t } = useTranslation();
-
+  const {
+    location,
+  } = props;
   const onDeleteClick = () => {
     offerHelpCollection.doc(props.id).delete();
   };
@@ -21,7 +23,7 @@ function Notification(props) {
       <div className="shadow rounded border mb-4 px-4 py-2 flex justify-between">
         {t('views.dashboard.youWillBeNotified')}
         {' '}
-        {props.location}
+        {location}
         {' '}
         {t('views.dashboard.needsHelp')}
         <button type="button" className="cursor-pointer font-bold" onClick={onDeleteClick}>

--- a/src/views/Dashboard.jsx
+++ b/src/views/Dashboard.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Redirect, Link } from 'react-router-dom';
+import { Link, Redirect } from 'react-router-dom';
 import { useAuthState } from 'react-firebase-hooks/auth';
 import { useCollectionData } from 'react-firebase-hooks/firestore';
 import { useTranslation } from 'react-i18next';
@@ -79,7 +79,19 @@ function Dashboard(props) {
             .
           </div>
         )
-        : requestsForHelp.map((entry) => (<Entry {...entry} key={entry.id} owner />))}
+        : requestsForHelp.map((entry) => (
+          <Entry
+            key={entry.id}
+            location={entry.location}
+            id={entry.id}
+            request={entry.request}
+            timestamp={entry.timestamp}
+            responses={entry.responses}
+            reportedBy={entry.reportedBy}
+            uid={entry.uid}
+            owner
+          />
+        ))}
 
       <h1 className="font-teaser py-4 pt-10">{t('views.dashboard.yourNotifications')}</h1>
 

--- a/src/views/FAQ.jsx
+++ b/src/views/FAQ.jsx
@@ -24,7 +24,7 @@ export default function FAQ() {
     );
   };
 
-  const QA = (props) => {
+  const QA = ({ question, children }) => {
     const {
       question,
       children,

--- a/src/views/FAQ.jsx
+++ b/src/views/FAQ.jsx
@@ -24,19 +24,12 @@ export default function FAQ() {
     );
   };
 
-  const QA = ({ question, children }) => {
-    const {
-      question,
-      children,
-    } = props;
-
-    return (
-      <>
-        <h2 className="text-xl font-teaser mt-8">{question}</h2>
-        <p className="font-open-sans">{children}</p>
-      </>
-    );
-  };
+  const QA = ({ question, children }) => (
+    <>
+      <h2 className="text-xl font-teaser mt-8">{question}</h2>
+      <p className="font-open-sans">{children}</p>
+    </>
+  );
 
   function buildFAQ(translationString) {
     return (i18n.exists(`views.faq.answers.${translationString}.preLink`))

--- a/src/views/FAQ.jsx
+++ b/src/views/FAQ.jsx
@@ -6,17 +6,17 @@ import Footer from '../components/Footer';
 export default function FAQ() {
   const { t, i18n } = useTranslation();
 
-  const QAwithLink = (props) => {
-    const hasPostLink = i18n.exists(`views.faq.answers.${props.translationKey}.postLink`);
-    const postLinkText = t(`views.faq.answers.${props.translationKey}.postLink`);
+  const QAwithLink = ({ translationKey }) => {
+    const hasPostLink = i18n.exists(`views.faq.answers.${translationKey}.postLink`);
+    const postLinkText = t(`views.faq.answers.${translationKey}.postLink`);
     const postLinkIsNotEmptyOrFullStop = postLinkText !== '' && postLinkText !== '.';
 
     return (
-      <QA key={props.translationKey} question={t(`views.faq.questions.${props.translationKey}`)}>
-        {t(`views.faq.answers.${props.translationKey}.preLink`)}
-        <Link to={t(`views.faq.answers.${props.translationKey}.url`)} className="text-secondary hover:underline">
+      <QA key={translationKey} question={t(`views.faq.questions.${translationKey}`)}>
+        {t(`views.faq.answers.${translationKey}.preLink`)}
+        <Link to={t(`views.faq.answers.${translationKey}.url`)} className="text-secondary hover:underline">
           {' '}
-          {t(`views.faq.answers.${props.translationKey}.link`)}
+          {t(`views.faq.answers.${translationKey}.link`)}
           {hasPostLink && postLinkIsNotEmptyOrFullStop ? ' ' : ''}
         </Link>
         {postLinkText}
@@ -24,12 +24,19 @@ export default function FAQ() {
     );
   };
 
-  const QA = (props) => (
-    <>
-      <h2 className="text-xl font-teaser mt-8">{props.question}</h2>
-      <p className="font-open-sans">{props.children}</p>
-    </>
-  );
+  const QA = (props) => {
+    const {
+      question,
+      children,
+    } = props;
+
+    return (
+      <>
+        <h2 className="text-xl font-teaser mt-8">{question}</h2>
+        <p className="font-open-sans">{children}</p>
+      </>
+    );
+  };
 
   function buildFAQ(translationString) {
     return (i18n.exists(`views.faq.answers.${translationString}.preLink`))

--- a/src/views/Impressum.jsx
+++ b/src/views/Impressum.jsx
@@ -81,7 +81,7 @@ export default function Impressum() {
           </p>
           <p>
             Diese Website benutzt Google Analytics, einen Webanalysedienst der Google Inc. (&apos;&apos;Google&apos;&apos;).
-            Google Analytics verwendet sog. &apos;&apos;Cookies&apos;&apos;, Textdateien, die auf Ihrem Computer gespeichert werden und die eine Analyse der Benutzung der
+            Google Analytics verwendet sog. &quot;Cookies&quot;, Textdateien, die auf Ihrem Computer gespeichert werden und die eine Analyse der Benutzung der
             Website durch Sie ermöglicht.
             Die durch den Cookie erzeugten Informationen über Ihre Benutzung dieser Website (einschließlich Ihrer IP-Adresse) wird an einen Server von
             Google in den USA übertragen und dort gespeichert.

--- a/src/views/Impressum.jsx
+++ b/src/views/Impressum.jsx
@@ -80,7 +80,7 @@ export default function Impressum() {
             <br />
           </p>
           <p>
-            Diese Website benutzt Google Analytics, einen Webanalysedienst der Google Inc. (&apos;&apos;Google&apos;&apos;).
+            Diese Website benutzt Google Analytics, einen Webanalysedienst der Google Inc. (&quot;Google&quot;).
             Google Analytics verwendet sog. &quot;Cookies&quot;, Textdateien, die auf Ihrem Computer gespeichert werden und die eine Analyse der Benutzung der
             Website durch Sie ermöglicht.
             Die durch den Cookie erzeugten Informationen über Ihre Benutzung dieser Website (einschließlich Ihrer IP-Adresse) wird an einen Server von

--- a/src/views/Impressum.jsx
+++ b/src/views/Impressum.jsx
@@ -80,8 +80,8 @@ export default function Impressum() {
             <br />
           </p>
           <p>
-            Diese Website benutzt Google Analytics, einen Webanalysedienst der Google Inc. (''Google'').
-            Google Analytics verwendet sog. ''Cookies'', Textdateien, die auf Ihrem Computer gespeichert werden und die eine Analyse der Benutzung der
+            Diese Website benutzt Google Analytics, einen Webanalysedienst der Google Inc. (&apos;&apos;Google&apos;&apos;).
+            Google Analytics verwendet sog. &apos;&apos;Cookies&apos;&apos;, Textdateien, die auf Ihrem Computer gespeichert werden und die eine Analyse der Benutzung der
             Website durch Sie ermöglicht.
             Die durch den Cookie erzeugten Informationen über Ihre Benutzung dieser Website (einschließlich Ihrer IP-Adresse) wird an einen Server von
             Google in den USA übertragen und dort gespeichert.

--- a/src/views/OfferHelp.jsx
+++ b/src/views/OfferHelp.jsx
@@ -65,7 +65,18 @@ export default function OfferHelp() {
         <div className="mt-4 p-1 font-teaser">
           {t('views.offerHelp.replyToRequest')}
         </div>
-        <Entry {...entry} showFullText highlightLeft key={entry.id} />
+        <Entry
+          key={entry.id}
+          location={entry.location}
+          id={entry.id}
+          request={entry.request}
+          timestamp={entry.timestamp}
+          responses={entry.responses}
+          reportedBy={entry.reportedBy}
+          uid={entry.uid}
+          showFullText
+          highlightLeft
+        />
         <div className="mt-4 p-1 w-full">
           <label htmlFor="offer-help-reply" className="text-gray-700 text-sm font-open-sans">{t('views.offerHelp.yourReply')}</label>
           <textarea

--- a/src/views/OfferHelp.jsx
+++ b/src/views/OfferHelp.jsx
@@ -67,8 +67,9 @@ export default function OfferHelp() {
         </div>
         <Entry {...entry} showFullText highlightLeft key={entry.id} />
         <div className="mt-4 p-1 w-full">
-          <label className="text-gray-700 text-sm font-open-sans">{t('views.offerHelp.yourReply')}</label>
+          <label htmlFor="offer-help-reply" className="text-gray-700 text-sm font-open-sans">{t('views.offerHelp.yourReply')}</label>
           <textarea
+            id="offer-help-reply"
             className="input-focus"
             onChange={(e) => setAnswer(e.target.value)}
             required="required"
@@ -76,8 +77,14 @@ export default function OfferHelp() {
           />
         </div>
         <div className="mt-1 w-full">
-          <label className="text-gray-700 text-sm font-open-sans">{t('views.offerHelp.yourEmail')}</label>
-          <MailInput className="input-focus" placeholder={t('views.offerHelp.placeholderEmail')} onChange={setEmail} defaultValue={email} />
+          <label htmlFor="your-email" className="text-gray-700 text-sm font-open-sans">{t('views.offerHelp.yourEmail')}</label>
+          <MailInput
+            id="your-email"
+            className="input-focus"
+            placeholder={t('views.offerHelp.placeholderEmail')}
+            onChange={setEmail}
+            defaultValue={email}
+          />
         </div>
         <div className="mt-4 m-1 w-full">
           {t('views.offerHelp.privacy')}

--- a/src/views/Press.jsx
+++ b/src/views/Press.jsx
@@ -216,7 +216,15 @@ export default function Press() {
             <img alt="bunte_de" src={require('../assets/bunte_de.jpg')} />
           </div>
         </div>
-        {articles.map((article) => <Article key={article.link || article.text} {...article} />)}
+        {articles.map((article) => (
+          <Article
+            key={article.link || article.text}
+            date={article.date}
+            title={article.title}
+            link={article.link}
+            text={article.text}
+          />
+        ))}
         <div className="bg-kaki p-4 mb-4 mt-4 font-open-sans w-full text-center">
           <div className="font-bold">Und viele mehr!</div>
         </div>

--- a/src/views/Press.jsx
+++ b/src/views/Press.jsx
@@ -26,15 +26,34 @@ export default function Press() {
     Sentry.captureException(errorGeneratingPressLink);
   }
 
-  const Article = (props) => (
-    <div className="bg-kaki p-4 mb-4 mt-4 font-open-sans w-full">
-      <div className="text-xs text-gray-700">{props.date}</div>
-      <div className="font-bold">{props.title}</div>
-      {props.link
-        ? <a className="text-secondary w-full block truncate" href={props.link} target="_blank" rel="nofollow noopener noreferrer">{props.link}</a>
-        : <span className="w-full block truncate">{props.text}</span>}
-    </div>
-  );
+  const Article = (props) => {
+    const {
+      date,
+      title,
+      link,
+      text,
+    } = props;
+
+    return (
+      <div className="bg-kaki p-4 mb-4 mt-4 font-open-sans w-full">
+        <div className="text-xs text-gray-700">{date}</div>
+        <div className="font-bold">{title}</div>
+        {link
+          ? (
+            <a
+              className="text-secondary w-full block truncate"
+              href={link}
+              target="_blank"
+              rel="nofollow noopener noreferrer"
+            >
+              {link}
+            </a>
+          ) : (
+            <span className="w-full block truncate">{text}</span>
+          )}
+      </div>
+    );
+  };
 
   const articles = [
     {

--- a/src/views/Press.jsx
+++ b/src/views/Press.jsx
@@ -26,34 +26,25 @@ export default function Press() {
     Sentry.captureException(errorGeneratingPressLink);
   }
 
-  const Article = (props) => {
-    const {
-      date,
-      title,
-      link,
-      text,
-    } = props;
-
-    return (
-      <div className="bg-kaki p-4 mb-4 mt-4 font-open-sans w-full">
-        <div className="text-xs text-gray-700">{date}</div>
-        <div className="font-bold">{title}</div>
-        {link
-          ? (
-            <a
-              className="text-secondary w-full block truncate"
-              href={link}
-              target="_blank"
-              rel="nofollow noopener noreferrer"
-            >
-              {link}
-            </a>
-          ) : (
-            <span className="w-full block truncate">{text}</span>
-          )}
-      </div>
-    );
-  };
+  const Article = ({ date, title, link, text }) => (
+    <div className="bg-kaki p-4 mb-4 mt-4 font-open-sans w-full">
+      <div className="text-xs text-gray-700">{date}</div>
+      <div className="font-bold">{title}</div>
+      {link
+        ? (
+          <a
+            className="text-secondary w-full block truncate"
+            href={link}
+            target="_blank"
+            rel="nofollow noopener noreferrer"
+          >
+            {link}
+          </a>
+        ) : (
+          <span className="w-full block truncate">{text}</span>
+        )}
+    </div>
+  );
 
   const articles = [
     {


### PR DESCRIPTION
**What changes does this PR introduce**
- Enable react/jsx-props-no-spreading eslint rule and fix code to be valid
- Enable react/destructuring-assignment eslintrc rule and fix code to be valid
- Enable react/no-unescaped-entities eslint rule  and fix code to be valid
- Remove jsx-a11y/click-events-have-key-events: off from eslintrc
- Enable jsx-a11y/label-has-associated-control eslint rule  and fix code to be valid
- Enable jsx-a11y/no-static-element-interactions eslint rule and fix code to be valid
- Enable prefer-destructuring eslint rule (19 hours ago)  and fix code to be valid

Please check those changes and I would appreciate if you could also test that everything is working as expected. I know some changes might be controversial, we can discuss them here! Each rule is in a separate commit, so we could also cherry-pick the ones that we want to have

This PR closes #66 
