### PR TITLE
Catch errors when parsing entries

### DIFF
--- a/src/components/EntryMap.jsx
+++ b/src/components/EntryMap.jsx
@@ -3,7 +3,7 @@ import GoogleMapReact from 'google-map-react';
 import '../styles/Map.css';
 import useSupercluster from 'use-supercluster';
 import { useTranslation } from 'react-i18next';
-
+import * as Sentry from '@sentry/browser';
 import fb from '../firebase';
 import Entry from './entry/Entry';
 import NotifyMe from './NotifyMe';
@@ -32,12 +32,24 @@ export default function EntryMap() {
 
   const [entries, setEntries] = useState([]);
 
+  function parseDoc(doc) {
+    try {
+      return { ...doc.data().d, id: doc.id };
+    } catch (err) {
+      Sentry.captureException(new Error(`Error parsing ask-for-help ${doc.id}`));
+      // eslint-disable-next-line no-console
+      console.error(`Error parsing ask-for-help ${doc.id}`);
+      return null;
+    }
+  }
+
   useEffect(() => {
     const fetchEntries = async () => {
       const queryResult = await fb.store.collection('ask-for-help').get();
 
       const entriesFromQuery = queryResult.docs
-        .map((document) => ({ ...document.data().d, id: document.id }))
+        .map(parseDoc)
+        .filter(Boolean) // filter entries that we weren't able to parse and are therefore null
         .map((dataPoint) => ({
           type: 'Feature',
           properties: {

--- a/src/components/EntryMap.jsx
+++ b/src/components/EntryMap.jsx
@@ -32,16 +32,14 @@ export default function EntryMap() {
 
   const [entries, setEntries] = useState([]);
 
-  function parseDoc(doc) {
+  const parseDoc = (doc) => {
     try {
       return { ...doc.data().d, id: doc.id };
     } catch (err) {
       Sentry.captureException(new Error(`Error parsing ask-for-help ${doc.id}`));
-      // eslint-disable-next-line no-console
-      console.error(`Error parsing ask-for-help ${doc.id}`);
       return null;
     }
-  }
+  };
 
   useEffect(() => {
     const fetchEntries = async () => {


### PR DESCRIPTION
Some entries have lat/lon zero which leads to an error
when we try to extract the data with the firebase library.

Instead of crashing when one entry has this problem, we
are now filtering out those invalid entries and logging
an error instead.

Note that in production we should not have those entries
and they indicate that something is wrong in another place,
which is why I've added reporting to sentry if any of those
invalid entries should occur.

Close #220