### PR TITLE
Use workflow to create a new sentry release on deploy

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -17,7 +17,7 @@ jobs:
           TOKEN: ${{ secrets.TOKEN }}
         run: ./.github/workflows/deploy-frontend.sh
       - name: Create a release on Sentry
-        runs: tclindner/sentry-release-action@v1.0.0
+        run: tclindner/sentry-release-action@v1.0.0
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           SENTRY_ORG: quarantine-hero

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -16,6 +16,15 @@ jobs:
         env:
           TOKEN: ${{ secrets.TOKEN }}
         run: ./.github/workflows/deploy-frontend.sh
+      - name: Create a release on Sentry
+        runs: tclindner/sentry-release-action@v1.0.0
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: quarantine-hero
+          SENTRY_PROJECT: quarantine-hero
+        with:
+          tagName: $ {{ github.sha }}
+          environment: production
 
   deploy-firebase:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -148,6 +148,6 @@ and follow the instructions.
 With all that, you should be good to go. In case you missed something or some step was unclear, please create an issue in this repository.
 
 # Necessary Environment variables for CI / CD
-- `TOKEN`: A GitHub used for committing code to the GH pages branch
+- `TOKEN`: A GitHub token used for committing code to the GH pages branch
 - `FIREBASE_TOKEN`: A Firebase token for deploying the functions to firebase
 - `SENTRY_AUTH_TOKEN`: A Sentry token used for creating a new release after deploying to production

--- a/README.md
+++ b/README.md
@@ -146,3 +146,8 @@ firebase deploy
 and follow the instructions.
 
 With all that, you should be good to go. In case you missed something or some step was unclear, please create an issue in this repository.
+
+# Necessary Environment variables for CI / CD
+- `TOKEN`: A GitHub used for committing code to the GH pages branch
+- `FIREBASE_TOKEN`: A Firebase token for deploying the functions to firebase
+- `SENTRY_AUTH_TOKEN`: A Sentry token used for creating a new release after deploying to production


### PR DESCRIPTION
This uses https://github.com/tclindner/sentry-releases-action to create
a new release on sentry whenever we deploy to production.

- [ ] Add SENTRY_AUTH_TOKEN to secrets
@kenodressel and @maurice22 please make sure to create such a secret
and add it to the project before merging this.

Close #222