### PR TITLE
Query param to display entry in attempt report state

### DIFF
--- a/firebase/functions/index.js
+++ b/firebase/functions/index.js
@@ -157,10 +157,11 @@ async function searchAndSendNotificationEmails() {
           from: 'help@quarantaenehelden.org',
           templateId: 'd-9e0d0ec8eda04c9a98e6cb1edffdac71',
           dynamic_template_data: {
-            subject: 'QuarantäneHelden - Jemand braucht deine Hilfe!',
+            subject: 'QuarantäneHelden - Jemand braucht Deine Hilfe!',
             request: askForHelpSnapData.d.request,
             location: askForHelpSnapData.d.location,
             link: `https://www.quarantaenehelden.org/#/offer-help/${askForHelpId}`,
+            reportLink: `https://www.quarantaenehelden.org/#/offer-help/${askForHelpId}?report=true`,
           },
           hideWarnings: true, // removes triple bracket warning
         });

--- a/firebase/functions/index.js
+++ b/firebase/functions/index.js
@@ -161,7 +161,7 @@ async function searchAndSendNotificationEmails() {
             request: askForHelpSnapData.d.request,
             location: askForHelpSnapData.d.location,
             link: `https://www.quarantaenehelden.org/#/offer-help/${askForHelpId}`,
-            reportLink: `https://www.quarantaenehelden.org/#/offer-help/${askForHelpId}?report=true`,
+            reportLink: `https://www.quarantaenehelden.org/#/offer-help/${askForHelpId}?report`,
           },
           hideWarnings: true, // removes triple bracket warning
         });

--- a/src/components/entry/Entry.jsx
+++ b/src/components/entry/Entry.jsx
@@ -30,6 +30,7 @@ export default function Entry(props) {
     responses = 0,
     highlightLeft = false,
     reportedBy = [],
+    report = false,
     uid = '',
   } = props;
 
@@ -45,7 +46,7 @@ export default function Entry(props) {
   const [solved, setSolved] = useState(false);
   const [attemptingToDelete, setAttemptingToDelete] = useState(false);
   const [attemptingToSolve, setAttemptingToSolve] = useState(false);
-  const [attemptingToReport, setAttemptingToReport] = useState(false);
+  const [attemptingToReport, setAttemptingToReport] = useState(report);
   const [popupVisible, setPopupVisible] = useState(false);
 
   const userIsLoggedIn = !!user && !!user.uid;

--- a/src/views/OfferHelp.jsx
+++ b/src/views/OfferHelp.jsx
@@ -59,6 +59,7 @@ export default function OfferHelp() {
 
   useEffect(() => {
     getUserData();
+    // Because we use the hash router, we cannot use the default functionality here as it would expect the query parameters before the hash
     const urlParams = new URLSearchParams(window.location.hash.split('?')[1]);
     setReport(urlParams.has('report'));
   }, []); // eslint-disable-line react-hooks/exhaustive-deps

--- a/src/views/OfferHelp.jsx
+++ b/src/views/OfferHelp.jsx
@@ -60,7 +60,7 @@ export default function OfferHelp() {
   useEffect(() => {
     getUserData();
     const urlParams = new URLSearchParams(window.location.hash.split('?')[1]);
-    setReport(!!urlParams.get('report'));
+    setReport(urlParams.has('report'));
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   if (!deleted) {

--- a/src/views/OfferHelp.jsx
+++ b/src/views/OfferHelp.jsx
@@ -61,7 +61,7 @@ export default function OfferHelp() {
     getUserData();
     const urlParams = new URLSearchParams(window.location.hash.split('?')[1]);
     setReport(!!urlParams.get('report'));
-  }, []);
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   if (!deleted) {
     return (

--- a/src/views/OfferHelp.jsx
+++ b/src/views/OfferHelp.jsx
@@ -13,6 +13,7 @@ export default function OfferHelp() {
   const [answer, setAnswer] = useState('');
   const [email, setEmail] = useState('');
   const [deleted, setDeleted] = useState(false);
+  const [report, setReport] = useState(false);
   const [entry, setEntry] = useState({
     id: null,
     uid: null,
@@ -56,7 +57,11 @@ export default function OfferHelp() {
     return history.push('/success-offer');
   };
 
-  useEffect(getUserData, []);
+  useEffect(() => {
+    getUserData();
+    const urlParams = new URLSearchParams(window.location.hash.split('?')[1]);
+    setReport(!!urlParams.get('report'));
+  }, []);
 
   if (!deleted) {
     return (
@@ -73,6 +78,7 @@ export default function OfferHelp() {
           responses={entry.responses}
           reportedBy={entry.reportedBy}
           uid={entry.uid}
+          report={report}
           showFullText
           highlightLeft
         />


### PR DESCRIPTION
**What changes does this PR introduce**

As suggested in #218, adding a link to report an entry would be nice. This PR introduces a query param "reported" to the /offer-help/{id} view. When set, the entry on this page will be displayed in the attemptReport state so that a user can report the post there. Furthermore, it passes this url to the sendgrid template.

Before this can be merged, we need to adapt the sendgrid template.
