### PR TITLE
Fixed data retrieval for geofirestore

### DIFF
--- a/src/util/parseDoc.js
+++ b/src/util/parseDoc.js
@@ -2,7 +2,8 @@ import * as Sentry from '@sentry/browser';
 
 export default function parseDoc(doc) {
   try {
-    return { ...doc.data().d, id: doc.id };
+    const data = doc.data();
+    return { ...(data.d || data), id: doc.id };
   } catch (err) {
     Sentry.captureException(new Error(`Error parsing ask-for-help ${doc.id}`));
     return null;


### PR DESCRIPTION
**What changes does this PR introduce**

Depending on which way we use to retrieve data (i.e. firestore or geofirestore) we need to access a different key. Was broken in last master in last deploy.