### PR TITLE
Remove QH logo duplication on mobile main page

### DIFF
--- a/src/styles/App.css
+++ b/src/styles/App.css
@@ -72,9 +72,6 @@
 .bg-kaki {
     background-color: #f9f7f0;
 }
-.logo-margin {
-    margin-left: -30px;
-}
 
 .entry {
     transition: 300ms;

--- a/src/views/Main.jsx
+++ b/src/views/Main.jsx
@@ -35,9 +35,6 @@ export default function Main() {
   return (
     <div className="flex items-center flex-col">
       <div className="phone-width">
-        <div className="font-main flex md:hidden text-white ">
-          <img className="logo-margin" src={(require('../assets/logo.svg'))} alt="logo" />
-        </div>
         <div className="flex text-center font-teaser justify-center w-full my-8 md:my-10">
           {t('views.main.weAreHumans')}
           <br />


### PR DESCRIPTION
**What changes does this PR introduce**

From the `Main` component, removes a logo which is only shown on mobile so that only the logo from the `MobileTopNavigation` component is visible. Closes #235. 