### PR TITLE
Fixed usage of wrong parameter

### DIFF
--- a/src/views/Signup.jsx
+++ b/src/views/Signup.jsx
@@ -22,7 +22,7 @@ export default () => {
   const { t } = useTranslation();
   const { returnUrl } = useParams();
 
-  const createUserWithEmailAndPassword = (mail, pw) => firebase.auth().createUserWithEmailAndPassword(email, pw);
+  const createUserWithEmailAndPassword = (mail, pw) => firebase.auth().createUserWithEmailAndPassword(mail, pw);
 
   if (user) {
     if (returnUrl) return <Redirect to={`/${decodeURIComponent(returnUrl)}`} />;


### PR DESCRIPTION
**What changes does this PR introduce**

When defining the signin function, instead of using the passed mail parameter, it is using the global email parameter (from the react state). This was fixed now.