### PR TITLE
add analytics events for engagement with entry

### DIFF
--- a/src/components/entry/Entry.jsx
+++ b/src/components/entry/Entry.jsx
@@ -69,6 +69,7 @@ export default function Entry(props) {
     await fb.store.collection('/deleted').doc(id).set({
       collectionName, ...doc.data(),
     });
+    await fb.analytics.logEvent('help_request_deleted');
     setDeleted(true);
     setAttemptingToDelete(false);
     setPopupVisible(true); // trigger the deletion confirmation popup
@@ -79,6 +80,7 @@ export default function Entry(props) {
     const askForHelpDoc = await fb.store.collection('ask-for-help').doc(id).get();
     const data = askForHelpDoc.data();
     await fb.store.collection('solved-posts').doc(id).set(data);
+    await fb.analytics.logEvent('help_request_solved');
     setSolved(true);
     setAttemptingToDelete(false);
     setPopupVisible(false);
@@ -135,6 +137,7 @@ export default function Entry(props) {
       timestamp: Date.now(),
     };
     await reportedPostsCollection.add(data);
+    await fb.analytics.logEvent('help_request_reported');
     setAttemptingToReport(false);
     return setReported(true);
   };

--- a/src/components/entry/Entry.jsx
+++ b/src/components/entry/Entry.jsx
@@ -69,7 +69,7 @@ export default function Entry(props) {
     await fb.store.collection('/deleted').doc(id).set({
       collectionName, ...doc.data(),
     });
-    await fb.analytics.logEvent('help_request_deleted');
+    fb.analytics.logEvent('help_request_deleted');
     setDeleted(true);
     setAttemptingToDelete(false);
     setPopupVisible(true); // trigger the deletion confirmation popup
@@ -80,7 +80,7 @@ export default function Entry(props) {
     const askForHelpDoc = await fb.store.collection('ask-for-help').doc(id).get();
     const data = askForHelpDoc.data();
     await fb.store.collection('solved-posts').doc(id).set(data);
-    await fb.analytics.logEvent('help_request_solved');
+    fb.analytics.logEvent('help_request_solved');
     setSolved(true);
     setAttemptingToDelete(false);
     setPopupVisible(false);
@@ -137,7 +137,7 @@ export default function Entry(props) {
       timestamp: Date.now(),
     };
     await reportedPostsCollection.add(data);
-    await fb.analytics.logEvent('help_request_reported');
+    fb.analytics.logEvent('help_request_reported');
     setAttemptingToReport(false);
     return setReported(true);
   };


### PR DESCRIPTION
**What changes does this PR introduce**
 
This PR introduces three new analytics events for the engagement with `ask-for-help` entries, namely:
* `help_request_deleted`
* `help_request_solved`
* `help_request_reported`

Adding these events allow us to run better analytics in the future. I tried to align the naming with the existing events, e.g. [success_request_help](https://github.com/kenodressel/quarantine-hero/blob/21075a4e8c50898dab9e3bf39617b767579914a3/src/views/Success.jsx#L8)