### PR TITLE
Bug fix: updated the logo inside the map

### DIFF
--- a/src/components/EntryMap.jsx
+++ b/src/components/EntryMap.jsx
@@ -180,7 +180,7 @@ export default function EntryMap() {
                   <img
                     className="help-request-image"
                     alt="help-marker"
-                    src={require('../assets/need_help.png')}
+                    src={require('../assets/help_white.svg')}
                   />
                 </button>
               </Marker>


### PR DESCRIPTION
I updated the asset reference in the img tag of the logo.
It now uses the new gender-fluid super hero who need help.

<img width="658" alt="image" src="https://user-images.githubusercontent.com/7671391/80366757-148ef900-888a-11ea-9316-218f90f50388.png">
