### PR TITLE
Add askForHelpId to sendgrid dynamic template variables for offer-help

### DIFF
--- a/firebase/functions/index.js
+++ b/firebase/functions/index.js
@@ -39,35 +39,27 @@ async function onOfferHelpCreate(snap) {
     const { email: receiver } = data.toJSON();
     const { answer, email } = offer.data();
 
-    // eslint-disable-next-line no-console
-    console.log({
+    const sendgridOptions = {
       to: receiver,
-      from: email,
+      from: 'help@quarantaenehelden.org',
       templateId: 'd-ed9746e4ff064676b7df121c81037fab',
+      replyTo: { email },
+      hideWarnings: true, // removes triple bracket warning
       dynamic_template_data: {
         subject: 'QuarantäneHeld*innen - Jemand hat Dir geschrieben!',
         answer,
         email,
         request,
+        askForHelpId: askForHelp.id,
       },
-    });
+    };
+
+    // eslint-disable-next-line no-console
+    console.log(sendgridOptions);
+
     try {
       if (SEND_EMAILS) {
-        await sgMail.send({
-          to: receiver,
-          from: 'help@quarantaenehelden.org',
-          replyTo: {
-            email,
-          },
-          templateId: 'd-ed9746e4ff064676b7df121c81037fab',
-          dynamic_template_data: {
-            subject: 'QuarantäneHeld*innen - Jemand hat Dir geschrieben!',
-            answer,
-            email,
-            request,
-          },
-          hideWarnings: true, // removes triple bracket warning
-        });
+        await sgMail.send(sendgridOptions);
       } else {
         // eslint-disable-next-line no-console
         console.log(sendingMailsDisabledLogMessage);

--- a/firebase/functions/index.js
+++ b/firebase/functions/index.js
@@ -50,7 +50,7 @@ async function onOfferHelpCreate(snap) {
         answer,
         email,
         request,
-        askForHelpId: askForHelp.id,
+        askForHelpLink: `https://www.quarantaenehelden.org/#/offer-help/${askForHelp.id}`,
       },
     };
 


### PR DESCRIPTION
**What changes does this PR introduce**
When a person asks for help (helpee) receives an offer from someone (helper) to help, we send an email to the helpee. Within this email we want to add a link back to the place where entry which was created by the helpee when asking for help. 

This PR adds the id of this entry in order to modify the email template to do this.

Closes #261 