### PR TITLE
Fix grammatical case of German timestamps for entries and responses

### DIFF
--- a/public/locales/de/translation.json
+++ b/public/locales/de/translation.json
@@ -274,7 +274,6 @@
       "repliesReceived": "Antworten erhalten",
       "somebodyAt": "Jemand in",
       "needsHelp": "braucht Hilfe!",
-      "before": "vor",
       "message": "{{count}} Nachricht",
       "message_plural": "{{count}} Nachrichten",
       "deleteRequestForHelp": "Löschen",

--- a/src/components/Responses.jsx
+++ b/src/components/Responses.jsx
@@ -4,7 +4,7 @@ import { de } from 'date-fns/locale';
 import loadResponses from '../services/loadResponses';
 
 const Response = ({ response }) => {
-  const date = formatDistance(new Date(response.timestamp), Date.now(), { locale: de });
+  const date = formatDistance(new Date(response.timestamp), Date.now(), { locale: de, addSuffix: true });
 
   return (
     <li className="px-4 py-2 my-1 block relative ml-12 font-open-sans response">
@@ -19,11 +19,7 @@ const Response = ({ response }) => {
         </a>
       </div>
       <p className="mt-2 mb-2 text-xl text-gray-800 whitespace-pre-line">{response.answer}</p>
-      <p className="text-gray-500 text-right text-xs">
-        vor
-        {' '}
-        {date}
-      </p>
+      <p className="text-gray-500 text-right text-xs">{date}</p>
     </li>
   );
 };

--- a/src/components/entry/Entry.jsx
+++ b/src/components/entry/Entry.jsx
@@ -39,7 +39,7 @@ export default function Entry(props) {
   const [user] = useAuthState(fb.auth);
   const link = useRef(null);
 
-  const date = formatDistance(new Date(timestamp), Date.now(), { locale: de }); // @TODO get locale from i18n.language or use i18n for formatting
+  const date = formatDistance(new Date(timestamp), Date.now(), { locale: de, addSuffix: true }); // @TODO get locale from i18n.language or use i18n for formatting
   const [responsesVisible, setResponsesVisible] = useState(false);
 
   const [deleted, setDeleted] = useState(false);
@@ -301,11 +301,7 @@ export default function Entry(props) {
         <p className="mt-2 mb-2 font-open-sans text-gray-800">{textToDisplay}</p>
         <div className="flex flex-row justify-between items-center mt-4 mb-2">
           <div className="text-xs text-secondary mr-1 font-bold">{mayDeleteEntryAndSeeResponses ? '' : numberOfResponsesText}</div>
-          <span className="text-gray-500 inline-block text-right text-xs font-open-sans">
-            {t('components.entry.before')}
-            {' '}
-            {date}
-          </span>
+          <span className="text-gray-500 inline-block text-right text-xs font-open-sans">{date}</span>
         </div>
         {buttonBar}
       </Link>


### PR DESCRIPTION
**What changes does this PR introduce**

Changes the timestamps for entries and responses so that they have correct grammar. Closes #265.

earlier: "vor etwa eine Stunde" -> now: "vor etwa einer Stunde"
earlier: "vor ein Tag" -> now: "vor einem Tag"
earlier: "vor 2 Tage" -> now: "vor 2 Tagen"
