### PR TITLE
Add function to serve hotline numbers from google sheet

### DIFF
--- a/firebase/functions/hotline.js
+++ b/firebase/functions/hotline.js
@@ -111,9 +111,9 @@ async function getPeopleForShift(shift) {
 }
 
 async function handleIncomingCall(req, res) {
-  const { authorization } = req.headers;
+  const { apikey } = req.query;
 
-  if (!authorization || !authorization.startsWith('Bearer ') || authorization.substr(7) !== API_KEY) {
+  if (!apikey || apikey !== API_KEY) {
     res.status(401).end();
     return;
   }

--- a/firebase/functions/hotline.js
+++ b/firebase/functions/hotline.js
@@ -1,0 +1,171 @@
+const { google } = require('googleapis');
+const { OAuth2Client } = require('google-auth-library');
+const admin = require('firebase-admin');
+const functions = require('firebase-functions');
+
+const SCOPES = ['https://www.googleapis.com/auth/spreadsheets'];
+const SPREADSHEET_ID = '1UsyHXG2_XQob7wGCrsSeSGyWt7sgmo-2Ez0ed3JQbdM';
+const RANGE = 'Verfuegbarkeiten!data';
+
+// eslint-disable-next-line camelcase
+const { client_id, client_secret } = functions.config().googlesheets;
+
+const REDIRECT_URL = 'https://europe-west1-qhero-stage.cloudfunctions.net/oauthCallback';
+const DB_TOKEN_PATH = '/google-sheets-api-tokens';
+
+const oauthClient = new OAuth2Client(client_id, client_secret, REDIRECT_URL);
+
+const weekdayIndex = {
+  'Monday Morning': 0,
+  'Monday Afternoon': 1,
+  'Tuesday Morning': 2,
+  'Tuesday Afternoon': 3,
+  'Wednesday Morning': 4,
+  'Wednesday Afternoon': 5,
+  'Thursday Morning': 6,
+  'Thursday Afternoon': 7,
+  'Friday Morning': 8,
+  'Friday Afternoon': 9,
+  'Saturday Morning': 10,
+  'Saturday Afternoon': 11,
+  'Sunday Morning': 12,
+  'Sunday Afternoon': 13,
+};
+
+const days = [
+  'Sunday',
+  'Monday',
+  'Tuesday',
+  'Wednesday',
+  'Thursday',
+  'Friday',
+  'Saturday',
+];
+
+function getCurrentShift() {
+  const now = new Date();
+  const day = days[now.getDay()];
+
+  // as long as this function is run in
+  // 'europe-west1' this will work properly
+  // because the time zone is identical to
+  // what we assume our call center hours
+  // in germany are
+  const hour = now.getHours();
+
+  let partOfDay;
+  switch (true) {
+    case hour >= 0 && hour < 10:
+      partOfDay = 'Night';
+      break;
+    case hour >= 10 && hour < 14:
+      partOfDay = 'Morning';
+      break;
+    case hour >= 14 && hour < 18:
+      partOfDay = 'Afternoon';
+      break;
+    case hour >= 18:
+      partOfDay = 'Night';
+      break;
+    default:
+      throw new Error(`Invalid hour ${hour}`);
+  }
+
+  return `${day} ${partOfDay}`;
+}
+
+async function getAuthorizedClient() {
+  const snapshot = await admin.database().ref(DB_TOKEN_PATH).once('value');
+  const oauthTokens = snapshot.val();
+  oauthClient.setCredentials(oauthTokens);
+
+  return oauthClient;
+}
+
+async function getValues(params) {
+
+  const sheets = google.sheets({ version: 'v4', auth: await getAuthorizedClient() });
+
+  return new Promise((resolve, reject) => {
+    sheets.spreadsheets.values.get(params, (err, res) => {
+      if (err) {
+        reject(err);
+      } else {
+        resolve(res);
+      }
+    });
+  });
+}
+
+function configureGoogleApiAccess(req, res) {
+  res.set('Cache-Control', 'private, max-age=0, s-maxage=0');
+  res.redirect(oauthClient.generateAuthUrl({
+    access_type: 'offline',
+    scope: SCOPES,
+    prompt: 'consent',
+  }));
+}
+
+async function oauthCallback(req, res) {
+  res.set('Cache-Control', 'private, max-age=0, s-maxage=0');
+  const { code } = req.query;
+  try {
+    const { tokens } = await oauthClient.getToken(code);
+    await admin.database().ref(DB_TOKEN_PATH).set(tokens);
+    return res.send('Successfully connected google sheets with firebase functions').status(200);
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.log(err);
+    return res.status(400).send(err);
+  }
+}
+
+async function getPeopleForShift(shift) {
+  const params = {
+    spreadsheetId: SPREADSHEET_ID,
+    range: RANGE,
+  };
+
+  const res = await getValues(params);
+  const rows = res.data.values;
+
+  if (!rows.length) {
+    throw new Error('No data found');
+  }
+
+  return rows
+    .map((row) => {
+      const number = row[1];
+      const availability = row.slice(2, row.length);
+
+      const rowIdx = weekdayIndex[shift];
+
+      return availability[rowIdx] === 'ja' ? number : null;
+    })
+    .filter(Boolean);
+}
+
+async function handleIncomingCall(req, res) {
+  // TODO: Secure with some kind of token as this exposes our phone numbers!
+  const shift = getCurrentShift();
+
+  try {
+    const people = await getPeopleForShift(shift);
+    if (people.length === 0) {
+      // Make it easier for Twilio Flow to check for empty string
+      res.status(200).send('');
+    } else {
+      res.status(200).send(people.join(','));
+    }
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.error(`An error occurred while retrieving numbers: ${err}`);
+    res.send('').status(500).end();
+  }
+}
+
+module.exports = {
+  handleIncomingCall,
+  configureGoogleApiAccess,
+  oauthCallback,
+};

--- a/firebase/functions/index.js
+++ b/firebase/functions/index.js
@@ -3,6 +3,7 @@ const admin = require('firebase-admin');
 const sgMail = require('@sendgrid/mail');
 const { GeoCollectionReference } = require('geofirestore');
 const slack = require('./slack');
+const { configureGoogleApiAccess, oauthCallback, handleIncomingCall } = require('./hotline.js');
 const { userIdsMatch, migrateResponses, deleteDocumentWithSubCollections } = require('./utils');
 
 admin.initializeApp();
@@ -354,3 +355,18 @@ exports.offerHelpCreate = functions
   .firestore
   .document('/ask-for-help/{requestId}/offer-help/{offerId}')
   .onCreate(onOfferHelpCreate);
+
+exports.configureGoogleApiAccess = functions
+  .region(REGION_EUROPE_WEST_1)
+  .https
+  .onRequest(configureGoogleApiAccess);
+
+exports.oauthCallback = functions
+  .region(REGION_EUROPE_WEST_1)
+  .https
+  .onRequest(oauthCallback);
+
+exports.handleIncomingCall = functions
+  .region(REGION_EUROPE_WEST_1)
+  .https
+  .onRequest(handleIncomingCall);

--- a/firebase/functions/index.js
+++ b/firebase/functions/index.js
@@ -3,7 +3,7 @@ const admin = require('firebase-admin');
 const sgMail = require('@sendgrid/mail');
 const { GeoCollectionReference } = require('geofirestore');
 const slack = require('./slack');
-const { configureGoogleApiAccess, oauthCallback, handleIncomingCall } = require('./hotline.js');
+const { handleIncomingCall } = require('./hotline.js');
 const { userIdsMatch, migrateResponses, deleteDocumentWithSubCollections } = require('./utils');
 
 admin.initializeApp();
@@ -355,16 +355,6 @@ exports.offerHelpCreate = functions
   .firestore
   .document('/ask-for-help/{requestId}/offer-help/{offerId}')
   .onCreate(onOfferHelpCreate);
-
-exports.configureGoogleApiAccess = functions
-  .region(REGION_EUROPE_WEST_1)
-  .https
-  .onRequest(configureGoogleApiAccess);
-
-exports.oauthCallback = functions
-  .region(REGION_EUROPE_WEST_1)
-  .https
-  .onRequest(oauthCallback);
 
 exports.handleIncomingCall = functions
   .region(REGION_EUROPE_WEST_1)

--- a/firebase/functions/package-lock.json
+++ b/firebase/functions/package-lock.json
@@ -536,6 +536,62 @@
         "google-auth-library": "^5.5.0",
         "retry-request": "^4.0.0",
         "teeny-request": "^6.0.0"
+      },
+      "dependencies": {
+        "gcp-metadata": {
+          "version": "3.5.0",
+          "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-3.5.0.tgz",
+          "integrity": "sha512-ZQf+DLZ5aKcRpLzYUyBS3yo3N0JSa82lNDO8rj3nMSlovLcz2riKFBsYgDzeXcv75oo5eqB2lx+B14UvPoCRnA==",
+          "optional": true,
+          "requires": {
+            "gaxios": "^2.1.0",
+            "json-bigint": "^0.3.0"
+          }
+        },
+        "google-auth-library": {
+          "version": "5.10.1",
+          "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-5.10.1.tgz",
+          "integrity": "sha512-rOlaok5vlpV9rSiUu5EpR0vVpc+PhN62oF4RyX/6++DG1VsaulAFEMlDYBLjJDDPI6OcNOCGAKy9UVB/3NIDXg==",
+          "optional": true,
+          "requires": {
+            "arrify": "^2.0.0",
+            "base64-js": "^1.3.0",
+            "ecdsa-sig-formatter": "^1.0.11",
+            "fast-text-encoding": "^1.0.0",
+            "gaxios": "^2.1.0",
+            "gcp-metadata": "^3.4.0",
+            "gtoken": "^4.1.0",
+            "jws": "^4.0.0",
+            "lru-cache": "^5.0.0"
+          }
+        },
+        "google-p12-pem": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/google-p12-pem/-/google-p12-pem-2.0.4.tgz",
+          "integrity": "sha512-S4blHBQWZRnEW44OcR7TL9WR+QCqByRvhNDZ/uuQfpxywfupikf/miba8js1jZi6ZOGv5slgSuoshCWh6EMDzg==",
+          "optional": true,
+          "requires": {
+            "node-forge": "^0.9.0"
+          }
+        },
+        "gtoken": {
+          "version": "4.1.4",
+          "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-4.1.4.tgz",
+          "integrity": "sha512-VxirzD0SWoFUo5p8RDP8Jt2AGyOmyYcT/pOUgDKJCK+iSw0TMqwrVfY37RXTNmoKwrzmDHSk0GMT9FsgVmnVSA==",
+          "optional": true,
+          "requires": {
+            "gaxios": "^2.1.0",
+            "google-p12-pem": "^2.0.0",
+            "jws": "^4.0.0",
+            "mime": "^2.2.0"
+          }
+        },
+        "node-forge": {
+          "version": "0.9.1",
+          "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.9.1.tgz",
+          "integrity": "sha512-G6RlQt5Sb4GMBzXvhfkeFmbqR6MzhtnT7VTHuLadjkii3rdYHNdw0m8zA4BTxVIh68FicCQ2NSUANpsqkr9jvQ==",
+          "optional": true
+        }
       }
     },
     "@google-cloud/firestore": {
@@ -842,7 +898,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
       "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
-      "optional": true,
       "requires": {
         "event-target-shim": "^5.0.0"
       }
@@ -872,7 +927,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.0.tgz",
       "integrity": "sha512-j1Q7cSCqN+AwrmDd+pzgqc0/NpC655x2bUf5ZjRIO77DcNBFmh+OgRNzF6OKdCC9RSCb19fGd99+bhXFdkRNqw==",
-      "optional": true,
       "requires": {
         "debug": "4"
       }
@@ -957,8 +1011,7 @@
     "arrify": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
-      "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==",
-      "optional": true
+      "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug=="
     },
     "ascli": {
       "version": "1.0.1",
@@ -1021,8 +1074,7 @@
     "base64-js": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
-      "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==",
-      "optional": true
+      "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
     },
     "bcrypt-pbkdf": {
       "version": "1.0.2",
@@ -1035,8 +1087,7 @@
     "bignumber.js": {
       "version": "7.2.1",
       "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-7.2.1.tgz",
-      "integrity": "sha512-S4XzBk5sMB+Rcb/LNcpzXr57VRTxgAvaAEDAl1AwRx27j00hT84O6OkteE7u8UB3NuaaygCRrEpqox4uDOrbdQ==",
-      "optional": true
+      "integrity": "sha512-S4XzBk5sMB+Rcb/LNcpzXr57VRTxgAvaAEDAl1AwRx27j00hT84O6OkteE7u8UB3NuaaygCRrEpqox4uDOrbdQ=="
     },
     "body-parser": {
       "version": "1.19.0",
@@ -1888,8 +1939,7 @@
     "event-target-shim": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
-      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
-      "optional": true
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="
     },
     "express": {
       "version": "4.17.1",
@@ -1988,8 +2038,7 @@
     "fast-text-encoding": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/fast-text-encoding/-/fast-text-encoding-1.0.1.tgz",
-      "integrity": "sha512-x4FEgaz3zNRtJfLFqJmHWxkMDDvXVtaznj2V9jiP8ACUJrUgist4bP9FmDL2Vew2Y9mEQI/tG4GqabaitYp9CQ==",
-      "optional": true
+      "integrity": "sha512-x4FEgaz3zNRtJfLFqJmHWxkMDDvXVtaznj2V9jiP8ACUJrUgist4bP9FmDL2Vew2Y9mEQI/tG4GqabaitYp9CQ=="
     },
     "faye-websocket": {
       "version": "0.11.3",
@@ -2308,13 +2357,26 @@
       }
     },
     "gcp-metadata": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-3.5.0.tgz",
-      "integrity": "sha512-ZQf+DLZ5aKcRpLzYUyBS3yo3N0JSa82lNDO8rj3nMSlovLcz2riKFBsYgDzeXcv75oo5eqB2lx+B14UvPoCRnA==",
-      "optional": true,
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-4.0.1.tgz",
+      "integrity": "sha512-hX2Ge7RJqESJ3gTfitpJWbdXqxxzgUFX5KVPhE02l9jq17rKKsTeB5h7v7Cky7yhLPfMYcirojC6VWU26lVyCQ==",
       "requires": {
-        "gaxios": "^2.1.0",
+        "gaxios": "^3.0.0",
         "json-bigint": "^0.3.0"
+      },
+      "dependencies": {
+        "gaxios": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-3.0.2.tgz",
+          "integrity": "sha512-cLOetrsKOBLPwjzVyFzirYaGjrhtYjbKUHp6fQpsio2HH8Mil35JTFQLgkV5D3CCXV7Gnd5V69/m4C9rMBi9bA==",
+          "requires": {
+            "abort-controller": "^3.0.0",
+            "extend": "^3.0.2",
+            "https-proxy-agent": "^5.0.0",
+            "is-stream": "^2.0.0",
+            "node-fetch": "^2.3.0"
+          }
+        }
       }
     },
     "gcs-resumable-upload": {
@@ -2329,6 +2391,62 @@
         "google-auth-library": "^5.0.0",
         "pumpify": "^2.0.0",
         "stream-events": "^1.0.4"
+      },
+      "dependencies": {
+        "gcp-metadata": {
+          "version": "3.5.0",
+          "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-3.5.0.tgz",
+          "integrity": "sha512-ZQf+DLZ5aKcRpLzYUyBS3yo3N0JSa82lNDO8rj3nMSlovLcz2riKFBsYgDzeXcv75oo5eqB2lx+B14UvPoCRnA==",
+          "optional": true,
+          "requires": {
+            "gaxios": "^2.1.0",
+            "json-bigint": "^0.3.0"
+          }
+        },
+        "google-auth-library": {
+          "version": "5.10.1",
+          "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-5.10.1.tgz",
+          "integrity": "sha512-rOlaok5vlpV9rSiUu5EpR0vVpc+PhN62oF4RyX/6++DG1VsaulAFEMlDYBLjJDDPI6OcNOCGAKy9UVB/3NIDXg==",
+          "optional": true,
+          "requires": {
+            "arrify": "^2.0.0",
+            "base64-js": "^1.3.0",
+            "ecdsa-sig-formatter": "^1.0.11",
+            "fast-text-encoding": "^1.0.0",
+            "gaxios": "^2.1.0",
+            "gcp-metadata": "^3.4.0",
+            "gtoken": "^4.1.0",
+            "jws": "^4.0.0",
+            "lru-cache": "^5.0.0"
+          }
+        },
+        "google-p12-pem": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/google-p12-pem/-/google-p12-pem-2.0.4.tgz",
+          "integrity": "sha512-S4blHBQWZRnEW44OcR7TL9WR+QCqByRvhNDZ/uuQfpxywfupikf/miba8js1jZi6ZOGv5slgSuoshCWh6EMDzg==",
+          "optional": true,
+          "requires": {
+            "node-forge": "^0.9.0"
+          }
+        },
+        "gtoken": {
+          "version": "4.1.4",
+          "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-4.1.4.tgz",
+          "integrity": "sha512-VxirzD0SWoFUo5p8RDP8Jt2AGyOmyYcT/pOUgDKJCK+iSw0TMqwrVfY37RXTNmoKwrzmDHSk0GMT9FsgVmnVSA==",
+          "optional": true,
+          "requires": {
+            "gaxios": "^2.1.0",
+            "google-p12-pem": "^2.0.0",
+            "jws": "^4.0.0",
+            "mime": "^2.2.0"
+          }
+        },
+        "node-forge": {
+          "version": "0.9.1",
+          "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.9.1.tgz",
+          "integrity": "sha512-G6RlQt5Sb4GMBzXvhfkeFmbqR6MzhtnT7VTHuLadjkii3rdYHNdw0m8zA4BTxVIh68FicCQ2NSUANpsqkr9jvQ==",
+          "optional": true
+        }
       }
     },
     "geofirestore": {
@@ -2382,20 +2500,33 @@
       }
     },
     "google-auth-library": {
-      "version": "5.10.1",
-      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-5.10.1.tgz",
-      "integrity": "sha512-rOlaok5vlpV9rSiUu5EpR0vVpc+PhN62oF4RyX/6++DG1VsaulAFEMlDYBLjJDDPI6OcNOCGAKy9UVB/3NIDXg==",
-      "optional": true,
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-6.0.0.tgz",
+      "integrity": "sha512-uLydy1t6SHN/EvYUJrtN3GCHFrnJ0c8HJjOxXiGjoTuYHIoCUT3jVxnzmjHwVnSdkfE9Akasm2rM6qG1COTXfQ==",
       "requires": {
         "arrify": "^2.0.0",
         "base64-js": "^1.3.0",
         "ecdsa-sig-formatter": "^1.0.11",
         "fast-text-encoding": "^1.0.0",
-        "gaxios": "^2.1.0",
-        "gcp-metadata": "^3.4.0",
-        "gtoken": "^4.1.0",
+        "gaxios": "^3.0.0",
+        "gcp-metadata": "^4.0.0",
+        "gtoken": "^5.0.0",
         "jws": "^4.0.0",
         "lru-cache": "^5.0.0"
+      },
+      "dependencies": {
+        "gaxios": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-3.0.2.tgz",
+          "integrity": "sha512-cLOetrsKOBLPwjzVyFzirYaGjrhtYjbKUHp6fQpsio2HH8Mil35JTFQLgkV5D3CCXV7Gnd5V69/m4C9rMBi9bA==",
+          "requires": {
+            "abort-controller": "^3.0.0",
+            "extend": "^3.0.2",
+            "https-proxy-agent": "^5.0.0",
+            "is-stream": "^2.0.0",
+            "node-fetch": "^2.3.0"
+          }
+        }
       }
     },
     "google-gax": {
@@ -2419,13 +2550,68 @@
         "retry-request": "^4.0.0",
         "semver": "^6.0.0",
         "walkdir": "^0.4.0"
+      },
+      "dependencies": {
+        "gcp-metadata": {
+          "version": "3.5.0",
+          "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-3.5.0.tgz",
+          "integrity": "sha512-ZQf+DLZ5aKcRpLzYUyBS3yo3N0JSa82lNDO8rj3nMSlovLcz2riKFBsYgDzeXcv75oo5eqB2lx+B14UvPoCRnA==",
+          "optional": true,
+          "requires": {
+            "gaxios": "^2.1.0",
+            "json-bigint": "^0.3.0"
+          }
+        },
+        "google-auth-library": {
+          "version": "5.10.1",
+          "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-5.10.1.tgz",
+          "integrity": "sha512-rOlaok5vlpV9rSiUu5EpR0vVpc+PhN62oF4RyX/6++DG1VsaulAFEMlDYBLjJDDPI6OcNOCGAKy9UVB/3NIDXg==",
+          "optional": true,
+          "requires": {
+            "arrify": "^2.0.0",
+            "base64-js": "^1.3.0",
+            "ecdsa-sig-formatter": "^1.0.11",
+            "fast-text-encoding": "^1.0.0",
+            "gaxios": "^2.1.0",
+            "gcp-metadata": "^3.4.0",
+            "gtoken": "^4.1.0",
+            "jws": "^4.0.0",
+            "lru-cache": "^5.0.0"
+          }
+        },
+        "google-p12-pem": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/google-p12-pem/-/google-p12-pem-2.0.4.tgz",
+          "integrity": "sha512-S4blHBQWZRnEW44OcR7TL9WR+QCqByRvhNDZ/uuQfpxywfupikf/miba8js1jZi6ZOGv5slgSuoshCWh6EMDzg==",
+          "optional": true,
+          "requires": {
+            "node-forge": "^0.9.0"
+          }
+        },
+        "gtoken": {
+          "version": "4.1.4",
+          "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-4.1.4.tgz",
+          "integrity": "sha512-VxirzD0SWoFUo5p8RDP8Jt2AGyOmyYcT/pOUgDKJCK+iSw0TMqwrVfY37RXTNmoKwrzmDHSk0GMT9FsgVmnVSA==",
+          "optional": true,
+          "requires": {
+            "gaxios": "^2.1.0",
+            "google-p12-pem": "^2.0.0",
+            "jws": "^4.0.0",
+            "mime": "^2.2.0"
+          }
+        },
+        "node-forge": {
+          "version": "0.9.1",
+          "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.9.1.tgz",
+          "integrity": "sha512-G6RlQt5Sb4GMBzXvhfkeFmbqR6MzhtnT7VTHuLadjkii3rdYHNdw0m8zA4BTxVIh68FicCQ2NSUANpsqkr9jvQ==",
+          "optional": true
+        }
       }
     },
     "google-p12-pem": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/google-p12-pem/-/google-p12-pem-2.0.4.tgz",
-      "integrity": "sha512-S4blHBQWZRnEW44OcR7TL9WR+QCqByRvhNDZ/uuQfpxywfupikf/miba8js1jZi6ZOGv5slgSuoshCWh6EMDzg==",
-      "optional": true,
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/google-p12-pem/-/google-p12-pem-3.0.1.tgz",
+      "integrity": "sha512-VlQgtozgNVVVcYTXS36eQz4PXPt9gIPqLOhHN0QiV6W6h4qSCNVKPtKC5INtJsaHHF2r7+nOIa26MJeJMTaZEQ==",
       "requires": {
         "node-forge": "^0.9.0"
       },
@@ -2433,8 +2619,43 @@
         "node-forge": {
           "version": "0.9.1",
           "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.9.1.tgz",
-          "integrity": "sha512-G6RlQt5Sb4GMBzXvhfkeFmbqR6MzhtnT7VTHuLadjkii3rdYHNdw0m8zA4BTxVIh68FicCQ2NSUANpsqkr9jvQ==",
-          "optional": true
+          "integrity": "sha512-G6RlQt5Sb4GMBzXvhfkeFmbqR6MzhtnT7VTHuLadjkii3rdYHNdw0m8zA4BTxVIh68FicCQ2NSUANpsqkr9jvQ=="
+        }
+      }
+    },
+    "googleapis": {
+      "version": "49.0.0",
+      "resolved": "https://registry.npmjs.org/googleapis/-/googleapis-49.0.0.tgz",
+      "integrity": "sha512-UoUuDbOzLxtU6fZnDyj6IvYvczBYP08RK3Sn0AknssQJceUYiHldaCjEFT1PDcT9MiKSJrbPze6PRdzQDny0Xw==",
+      "requires": {
+        "google-auth-library": "^6.0.0",
+        "googleapis-common": "^4.0.0"
+      }
+    },
+    "googleapis-common": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/googleapis-common/-/googleapis-common-4.1.0.tgz",
+      "integrity": "sha512-/T+GflstRAbXbf33zeutDXhXj25I1gKwaWNJ4kWSJVSVpXIZugOX8K7iq3uFCQCOJzehPuPLAC2u8iEf6jN0dw==",
+      "requires": {
+        "extend": "^3.0.2",
+        "gaxios": "^3.0.0",
+        "google-auth-library": "^6.0.0",
+        "qs": "^6.7.0",
+        "url-template": "^2.0.8",
+        "uuid": "^7.0.0"
+      },
+      "dependencies": {
+        "gaxios": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-3.0.2.tgz",
+          "integrity": "sha512-cLOetrsKOBLPwjzVyFzirYaGjrhtYjbKUHp6fQpsio2HH8Mil35JTFQLgkV5D3CCXV7Gnd5V69/m4C9rMBi9bA==",
+          "requires": {
+            "abort-controller": "^3.0.0",
+            "extend": "^3.0.2",
+            "https-proxy-agent": "^5.0.0",
+            "is-stream": "^2.0.0",
+            "node-fetch": "^2.3.0"
+          }
         }
       }
     },
@@ -2941,15 +3162,28 @@
       }
     },
     "gtoken": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-4.1.4.tgz",
-      "integrity": "sha512-VxirzD0SWoFUo5p8RDP8Jt2AGyOmyYcT/pOUgDKJCK+iSw0TMqwrVfY37RXTNmoKwrzmDHSk0GMT9FsgVmnVSA==",
-      "optional": true,
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-5.0.1.tgz",
+      "integrity": "sha512-33w4FNDkUcyIOq/TqyC+drnKdI4PdXmWp9lZzssyEQKuvu9ZFN3KttaSnDKo52U3E51oujVGop93mKxmqO8HHg==",
       "requires": {
-        "gaxios": "^2.1.0",
-        "google-p12-pem": "^2.0.0",
+        "gaxios": "^3.0.0",
+        "google-p12-pem": "^3.0.0",
         "jws": "^4.0.0",
         "mime": "^2.2.0"
+      },
+      "dependencies": {
+        "gaxios": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-3.0.2.tgz",
+          "integrity": "sha512-cLOetrsKOBLPwjzVyFzirYaGjrhtYjbKUHp6fQpsio2HH8Mil35JTFQLgkV5D3CCXV7Gnd5V69/m4C9rMBi9bA==",
+          "requires": {
+            "abort-controller": "^3.0.0",
+            "extend": "^3.0.2",
+            "https-proxy-agent": "^5.0.0",
+            "is-stream": "^2.0.0",
+            "node-fetch": "^2.3.0"
+          }
+        }
       }
     },
     "har-schema": {
@@ -3087,7 +3321,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
       "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
-      "optional": true,
       "requires": {
         "agent-base": "6",
         "debug": "4"
@@ -3358,8 +3591,7 @@
     "is-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
-      "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
-      "optional": true
+      "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw=="
     },
     "is-stream-ended": {
       "version": "0.1.4",
@@ -3467,7 +3699,6 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-0.3.0.tgz",
       "integrity": "sha1-DM2RLEuCcNBfBW+9E4FLU9OCWx4=",
-      "optional": true,
       "requires": {
         "bignumber.js": "^7.0.0"
       }
@@ -3546,7 +3777,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.0.tgz",
       "integrity": "sha512-jrZ2Qx916EA+fq9cEAeCROWPTfCwi1IVHqT2tapuqLEVVDKFDENFw1oL+MwrTvH6msKxsd1YTDVw6uKEcsrLEA==",
-      "optional": true,
       "requires": {
         "buffer-equal-constant-time": "1.0.1",
         "ecdsa-sig-formatter": "1.0.11",
@@ -3557,7 +3787,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.0.tgz",
       "integrity": "sha512-KDncfTmOZoOMTFG4mBlG0qUIOlc03fmzH+ru6RgYVZhPkyiy/92Owlt/8UEN+a4TXR1FQetfIpJE8ApdvdVxTg==",
-      "optional": true,
       "requires": {
         "jwa": "^2.0.0",
         "safe-buffer": "^5.0.1"
@@ -3678,7 +3907,6 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
       "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-      "optional": true,
       "requires": {
         "yallist": "^3.0.2"
       }
@@ -3710,8 +3938,7 @@
     "mime": {
       "version": "2.4.4",
       "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.4.tgz",
-      "integrity": "sha512-LRxmNwziLPT828z+4YkNzloCFC2YM4wrB99k+AV5ZbEyfGNWfG8SO1FUXLmLDBSo89NrJZ4DIWeLjy1CHGhMGA==",
-      "optional": true
+      "integrity": "sha512-LRxmNwziLPT828z+4YkNzloCFC2YM4wrB99k+AV5ZbEyfGNWfG8SO1FUXLmLDBSo89NrJZ4DIWeLjy1CHGhMGA=="
     },
     "mime-db": {
       "version": "1.43.0",
@@ -3792,8 +4019,7 @@
     "node-fetch": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
-      "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==",
-      "optional": true
+      "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
     },
     "node-forge": {
       "version": "0.7.4",
@@ -4836,6 +5062,11 @@
         "punycode": "^2.1.0"
       }
     },
+    "url-template": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/url-template/-/url-template-2.0.8.tgz",
+      "integrity": "sha1-/FZaPMy/93MMd19WQflVV5FDnyE="
+    },
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -4850,8 +5081,7 @@
     "uuid": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.2.tgz",
-      "integrity": "sha512-vy9V/+pKG+5ZTYKf+VcphF5Oc6EFiu3W8Nv3P3zIh0EqVI80ZxOzuPfe9EHjkFNvf8+xuTHVeei4Drydlx4zjw==",
-      "optional": true
+      "integrity": "sha512-vy9V/+pKG+5ZTYKf+VcphF5Oc6EFiu3W8Nv3P3zIh0EqVI80ZxOzuPfe9EHjkFNvf8+xuTHVeei4Drydlx4zjw=="
     },
     "v8-compile-cache": {
       "version": "2.1.0",
@@ -5019,8 +5249,7 @@
     "yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-      "optional": true
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
     },
     "yargs": {
       "version": "3.32.0",

--- a/firebase/functions/package.json
+++ b/firebase/functions/package.json
@@ -17,7 +17,9 @@
     "axios": "^0.19.2",
     "firebase-admin": "^8.6.0",
     "firebase-functions": "^3.3.0",
-    "geofirestore": "^3.4.1"
+    "geofirestore": "^3.4.1",
+    "google-auth-library": "^6.0.0",
+    "googleapis": "^49.0.0"
   },
   "devDependencies": {
     "eslint": "^6.8.0",

--- a/firebase/functions/package.json
+++ b/firebase/functions/package.json
@@ -18,7 +18,6 @@
     "firebase-admin": "^8.6.0",
     "firebase-functions": "^3.3.0",
     "geofirestore": "^3.4.1",
-    "google-auth-library": "^6.0.0",
     "googleapis": "^49.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
**What changes does this PR introduce**
This adds a firebase function `handleIncomingCall` which allows use to expose phone numbers from a call sheet in google drive via http.

```
Twilio <--> Firebase Function <--> Google Sheets API
```

A request to `handleIncomingCall` will return a list of phone numbers that are available to pick up calls right now as comma-separated values. All requests to this endpoint are protected by a token.

**Checklist before deploying this function**
Set the following config values accordingly
- [x] sheet_id
- [x] range
- [x] service_account_email
- [x] private_key
- [x] api_key

Use the command 
```sh
firebase functions:config:set googleSheets.<key>=<VALUE> --project quarantine-hero
```


**Checklist after deploying this function**
- Set the URL of the `handleIncomingCall` in Twilio studio

**Others details**
- [x] This PR introduces a new dependency. Reason:  `googleapis` for access to google sheets via API  

There unfortunately is no issue to track this right now, as I originally wasn't even planning to contribute this to the code base and it evolved from a PoC. Sorry!