### PR TITLE
Hotfix/add hotline timezone support

### DIFF
--- a/firebase/functions/hotline.js
+++ b/firebase/functions/hotline.js
@@ -1,5 +1,6 @@
 const { google } = require('googleapis');
 const functions = require('firebase-functions');
+const moment = require('moment-timezone');
 
 const {
   sheet_id: SPREADSHEET_ID,
@@ -39,15 +40,8 @@ const days = [
 ];
 
 function getCurrentShift() {
-  const now = new Date();
-  const day = days[now.getDay()];
-
-  // FIXME: as long as this function is run in
-  // 'europe-west1' this will work properly
-  // because the time zone is identical to
-  // what we assume our call center hours
-  // in germany are
-  const hour = now.getHours();
+  const day = days[moment().tz('Europe/Berlin').get('day')];
+  const hour = moment().tz('Europe/Berlin').get('hour');
 
   let partOfDay;
   switch (true) {

--- a/firebase/functions/package-lock.json
+++ b/firebase/functions/package-lock.json
@@ -3982,6 +3982,14 @@
         "minimist": "^1.2.5"
       }
     },
+    "moment-timezone": {
+      "version": "0.5.28",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.28.tgz",
+      "integrity": "sha512-TDJkZvAyKIVWg5EtVqRzU97w0Rb0YVbfpqyjgu6GwXCAohVRqwZjf4fOzDE6p1Ch98Sro/8hQQi65WDXW5STPw==",
+      "requires": {
+        "moment": ">= 2.9.0"
+      }
+    },
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",

--- a/firebase/functions/package-lock.json
+++ b/firebase/functions/package-lock.json
@@ -3982,6 +3982,11 @@
         "minimist": "^1.2.5"
       }
     },
+    "moment": {
+      "version": "2.25.3",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.25.3.tgz",
+      "integrity": "sha512-PuYv0PHxZvzc15Sp8ybUCoQ+xpyPWvjOuK72a5ovzp2LI32rJXOiIfyoFoYvG3s6EwwrdkMyWuRiEHSZRLJNdg=="
+    },
     "moment-timezone": {
       "version": "0.5.28",
       "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.28.tgz",

--- a/firebase/functions/package.json
+++ b/firebase/functions/package.json
@@ -18,7 +18,8 @@
     "firebase-admin": "^8.6.0",
     "firebase-functions": "^3.3.0",
     "geofirestore": "^3.4.1",
-    "googleapis": "^49.0.0"
+    "googleapis": "^49.0.0",
+    "moment-timezone": "^0.5.28"
   },
   "devDependencies": {
     "eslint": "^6.8.0",


### PR DESCRIPTION
**What changes does this PR introduce**
Use proper timezones for the hotline so that the hours actually match our hours in the sheet.
I've tested these changes in the emulator locally to verify they work as expected.

**Others details**
- [x] This PR introduces a new dependency. Reason: Using moment-timezone in order to have an easy way of dealing with timezone support

